### PR TITLE
[codex] expose session fs metadata

### DIFF
--- a/# Guia focado — Conexão do ChatGPT ao VS.md
+++ b/# Guia focado — Conexão do ChatGPT ao VS.md
@@ -1,0 +1,996 @@
+# Guia focado — Conexão do ChatGPT ao VS Code em WSL2 Docker Dev Container via MCP
+
+**Versão:** 2.0 — guia focado de conexão
+**Ambiente-alvo:** Windows + WSL2 + Docker Desktop + VS Code Dev Containers + Node 24 + GitHub Copilot SDK 0.3.0
+**Objetivo:** permitir que o ChatGPT em `https://chatgpt.com/`, e também outras LLMs compatíveis, conectem-se ao repositório real aberto no VS Code dentro de um Dev Container, por meio de um MCP server local controlado, rápido, auditável e com ampla capacidade operacional.
+https://developers.openai.com/apps-sdk/quickstart
+
+---
+
+## Índice
+
+1. Propósito do documento
+2. A ideia central em uma página
+3. Vocabulário mínimo
+4. O que significa “conectar o ChatGPT ao VS Code”
+5. Topologia recomendada
+6. Papel do WSL2
+7. Papel do Docker Dev Container
+8. Papel do Node 24
+9. Papel do MCP server
+10. Transportes: stdio, Streamable HTTP e SSE
+11. Por que o ChatGPT precisa de `/mcp` via HTTPS ou túnel
+12. Secure MCP Tunnel
+13. O formulário do ChatGPT mostrado na imagem
+14. Autenticação e confiança
+15. Como o MCP server deve enxergar o repositório
+16. Tools essenciais do MCP server
+17. Tools intermediárias
+18. Tools avançadas
+19. VS Code usando o mesmo MCP server
+20. GitHub Copilot SDK 0.3.0 no desenho
+21. Copilot CLI headless + `cliUrl`
+22. Como outras LLMs entram no sistema
+23. Memória operacional compartilhada
+24. Segurança sem amputar liberdade
+25. Fluxo de implementação recomendado
+26. Smoke tests
+27. Diagnóstico de falhas comuns
+28. Decisões canônicas
+29. Fontes oficiais
+30. Conclusão
+
+---
+
+## 1. Propósito do documento
+
+Este documento concentra-se em uma única pergunta prática:
+
+> Como fazer o ChatGPT, pela interface `chatgpt.com`, conectar-se ao nosso repositório real aberto no VS Code, dentro de WSL2 + Docker Dev Container, e operar esse projeto por meio de um MCP server escrito para Node 24?
+
+O foco aqui não é explicar toda a plataforma de agentes, nem fornecer código completo. O foco é a conexão: o caminho físico, lógico e protocolar entre a conversa no ChatGPT e o ambiente real de desenvolvimento.
+
+O documento também considera o GitHub Copilot SDK 0.3.0, não como substituto do MCP, mas como uma camada local adicional para orquestração, execução assistida e possível delegação a um agente Copilot rodando dentro do mesmo ambiente do projeto.
+
+---
+
+## 2. A ideia central em uma página
+
+O ChatGPT não acessa diretamente o seu VS Code, seu terminal, seu `localhost` do Windows ou seu filesystem. O ChatGPT acessa **um servidor MCP**.
+
+Esse MCP server, por sua vez, roda no mesmo ambiente onde o projeto realmente vive: o Dev Container do VS Code, dentro do WSL2/Docker.
+
+A topologia ideal é:
+
+```text
+ChatGPT em chatgpt.com
+  ↓ conector MCP
+Endpoint HTTPS /mcp ou Secure MCP Tunnel
+  ↓
+MCP server Node 24 dentro do Dev Container
+  ↓
+Project Control Plane
+  ↓
+/workspaces/<repo> — o repositório real do VS Code
+```
+
+Para uso local, o VS Code e outros clientes dentro do container podem usar `stdio`. Para o ChatGPT remoto, o transporte correto é Streamable HTTP em `/mcp`, exposto por HTTPS ou por Secure MCP Tunnel.
+
+A documentação oficial do ChatGPT Apps SDK indica que o conector deve receber a URL pública do endpoint `/mcp` do servidor. Para desenvolvimento local, essa URL precisa ser alcançável por HTTPS, normalmente via túnel.
+Fonte oficial: https://developers.openai.com/apps-sdk/deploy/connect-chatgpt
+
+---
+
+## 3. Vocabulário mínimo
+
+### ChatGPT
+
+A interface em `https://chatgpt.com/`. Neste documento, “ChatGPT” significa esta superfície remota da OpenAI, capaz de chamar tools por meio de um app/conector MCP.
+
+### VS Code
+
+O editor usado pelo humano. Ele está conectado ao ambiente WSL2 e reabre o projeto dentro de um Dev Container.
+
+### WSL2
+
+O ambiente Linux real dentro do Windows. Deve conter o clone do projeto para evitar a lentidão do filesystem `C:\` quando usado por Docker e ferramentas Linux.
+
+### Docker Dev Container
+
+O container de desenvolvimento aberto pelo VS Code. É o ambiente onde o Node 24, Git, dependências, scripts e o MCP server rodam.
+
+### MCP
+
+Model Context Protocol. É o protocolo que permite que aplicações de IA descubram e chamem tools, leiam resources e usem prompts expostos por um servidor externo.
+
+### MCP server
+
+O processo que publicará as capacidades do projeto. Ele deve ser escrito de modo a acessar o repo real e executar operações controladas.
+
+### Tool
+
+Uma função publicada pelo MCP server. Exemplos: ler arquivo, buscar no repo, retornar `git diff`, rodar teste, aplicar patch, criar branch.
+
+### Transport
+
+O meio pelo qual o cliente MCP e o servidor MCP trocam mensagens. Neste projeto, os transportes relevantes são `stdio` e Streamable HTTP. SSE fica apenas como fallback legado.
+
+### Project Control Plane
+
+A camada local que organiza operações sobre o projeto: filesystem, Git, jobs, logs, auditoria, locks, permissões, memória operacional e integração com Copilot.
+
+---
+
+## 4. O que significa “conectar o ChatGPT ao VS Code”
+
+A expressão pode ser enganosa. O ChatGPT não “entra” no VS Code. O que fazemos é:
+
+1. Rodar um MCP server dentro do mesmo Dev Container do VS Code.
+2. Dar a esse servidor acesso ao repositório real.
+3. Expor o servidor ao ChatGPT por um endpoint `/mcp` seguro.
+4. Cadastrar esse endpoint no formulário de “Novo app” ou “Conector” do ChatGPT.
+5. Permitir que o ChatGPT chame as tools do MCP server durante a conversa.
+
+Portanto, a conexão real é:
+
+```text
+ChatGPT → MCP endpoint → MCP server → repo no Dev Container
+```
+
+O VS Code aparece porque é o ambiente humano de edição e porque o Dev Container aberto no VS Code é o lugar onde tudo deve rodar.
+
+---
+
+## 5. Topologia recomendada
+
+### Topologia lógica
+
+```text
+Humano
+  ↓
+ChatGPT em chatgpt.com
+  ↓
+Custom App / Connector MCP
+  ↓
+Secure MCP Tunnel ou HTTPS público
+  ↓
+MCP server Node 24
+  ↓
+Project Control Plane
+  ↓
+Repo real + Git + scripts + logs
+```
+
+### Topologia física
+
+```text
+Windows
+  ↓
+WSL2
+  ↓
+Docker Desktop com backend WSL2
+  ↓
+VS Code Dev Container
+  ↓
+Node 24 + MCP server + Copilot SDK + repo
+```
+
+### Regra fundamental
+
+O MCP server deve rodar onde o repo é real. Se o projeto está em `/workspaces/meu-repo` dentro do Dev Container, o MCP server deve rodar nesse mesmo container ou em um container com o mesmo mount, os mesmos caminhos e o mesmo contexto Git.
+
+---
+
+## 6. Papel do WSL2
+
+O WSL2 é a base Linux dentro do Windows. Para projetos com Docker e Dev Containers, o local do filesystem importa muito.
+
+A Microsoft recomenda que projetos usados com Dev Containers no Windows fiquem no filesystem do WSL2, por exemplo:
+
+```text
+/home/<usuario>/projects/<repo>
+```
+
+Evite manter o projeto em:
+
+```text
+C:\Users\<usuario>\projects\<repo>
+```
+
+Motivo: quando o Docker acessa arquivos no filesystem Windows a partir de um container Linux, há uma ponte cross-OS mais lenta. Com o repo no filesystem WSL2, o I/O fica mais próximo de Linux nativo.
+
+Fonte oficial: https://learn.microsoft.com/en-us/windows/dev-environment/docker/dev-containers
+
+---
+
+## 7. Papel do Docker Dev Container
+
+O Dev Container torna o ambiente reprodutível. Em vez de depender do Node, Git, scripts e ferramentas instaladas no Windows, o projeto define seu ambiente em container.
+
+O Dev Container deve conter:
+
+- Node 24.
+- Git.
+- Ferramentas de build/test/lint do projeto.
+- Dependências necessárias ao MCP server.
+- Dependências necessárias ao GitHub Copilot SDK 0.3.0, quando aplicável.
+- Acesso ao repo em `/workspaces/<repo>`.
+- Local persistente para `.ai/`, logs, histórico de jobs e estado operacional.
+
+O VS Code permite configurar MCP servers dentro de Dev Containers por meio da seção `customizations.vscode.mcp` no `devcontainer.json`.
+
+Fonte oficial: https://code.visualstudio.com/docs/copilot/customization/mcp-servers
+
+---
+
+## 8. Papel do Node 24
+
+Node 24 é o runtime principal do nosso MCP server e do Project Control Plane.
+
+Ele é apropriado porque permite:
+
+- Servidor HTTP para Streamable HTTP `/mcp`.
+- CLI local para ferramentas auxiliares.
+- Integração com Git, shells e processos do projeto.
+- Uso de ESM moderno.
+- Controle de subprocessos e jobs.
+- Integração com o GitHub Copilot SDK 0.3.0.
+
+A recomendação arquitetural é usar Node 24 com ESM puro, separando:
+
+```text
+core do projeto
+  tools determinísticas
+  git/filesystem/jobs
+  auditoria/memória
+
+adaptadores MCP
+  stdio local
+  Streamable HTTP /mcp remoto
+
+integrações
+  Copilot SDK
+  terminal broker
+  repo-ai CLI
+```
+
+O Node Permission Model pode ser usado como mitigação operacional, mas não deve ser tratado como sandbox absoluto. Para liberdade ampla com segurança, a camada mais importante é o próprio desenho do MCP server: paths restritos ao workspace, logs, grants, locks e auditoria.
+
+Fonte oficial: https://nodejs.org/docs/latest-v24.x/api/permissions.html
+
+---
+
+## 9. Papel do MCP server
+
+O MCP server é a peça que transforma o repositório em uma superfície controlável por LLMs.
+
+Ele deve:
+
+- Declarar tools de forma clara.
+- Validar argumentos.
+- Executar operações no repo real.
+- Retornar resultados estruturados.
+- Controlar permissões.
+- Registrar auditoria.
+- Impedir fuga acidental para fora do workspace.
+- Ser rápido para leituras comuns.
+- Ser previsível para escrita e execução.
+
+A documentação da OpenAI descreve que o MCP server define tools, aplica autenticação e retorna dados; o modelo decide quando chamar as tools com base na descrição e metadados.
+Fonte oficial: https://developers.openai.com/apps-sdk/build/mcp-server
+
+---
+
+## 10. Transportes: stdio, Streamable HTTP e SSE
+
+### `stdio`
+
+`stdio` é o transporte local. O cliente inicia o processo do MCP server e fala com ele por stdin/stdout.
+
+Use para:
+
+- VS Code local.
+- Copilot SDK local.
+- Testes dentro do Dev Container.
+- Ferramentas que rodam no mesmo namespace do projeto.
+
+Não use como conexão direta do ChatGPT remoto, porque o ChatGPT não consegue iniciar um processo dentro do seu WSL2/Dev Container.
+
+### Streamable HTTP
+
+Streamable HTTP é o transporte remoto moderno do MCP. O servidor expõe um endpoint único, normalmente:
+
+```text
+/mcp
+```
+
+A especificação MCP define que esse transporte usa HTTP `POST` e `GET`, e pode usar SSE internamente para streaming. O servidor deve oferecer um único endpoint MCP que suporte esses métodos.
+
+Use para:
+
+- ChatGPT em `chatgpt.com`.
+- Secure MCP Tunnel.
+- API Playground.
+- Outras LLMs remotas.
+- Clientes que precisam de conexão de rede.
+
+Fonte oficial: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports
+
+### SSE legado
+
+SSE legado é o transporte antigo HTTP+SSE. Ele costuma envolver endpoints separados, como `/sse` e `/messages`.
+
+Use apenas se um cliente antigo exigir. Não deve ser a fundação nova do projeto.
+
+### Regra simples
+
+```text
+Dentro do Dev Container: stdio.
+Fora do Dev Container, incluindo ChatGPT: Streamable HTTP /mcp.
+SSE legado: apenas fallback.
+```
+
+---
+
+## 11. Por que o ChatGPT precisa de `/mcp` via HTTPS ou túnel
+
+O ChatGPT em `chatgpt.com` roda fora da sua máquina. Ele não conhece o `localhost` do seu Windows, nem o `localhost` do WSL2, nem o `localhost` do container.
+
+Por isso, quando você preenche o formulário de conector no ChatGPT, o campo “URL do servidor MCP” precisa apontar para uma URL que o ChatGPT consiga alcançar.
+
+A documentação oficial de conexão do ChatGPT diz para fornecer a URL pública do endpoint `/mcp`, como no padrão:
+
+```text
+https://<host-publico-ou-tunel>/mcp
+```
+
+Fonte oficial: https://developers.openai.com/apps-sdk/deploy/connect-chatgpt
+
+No nosso caso, como o MCP server é privado e local, a opção mais alinhada é usar Secure MCP Tunnel.
+
+---
+
+## 12. Secure MCP Tunnel
+
+O Secure MCP Tunnel permite conectar servidores MCP privados a produtos OpenAI sem expor o servidor diretamente à internet.
+
+A lógica é:
+
+```text
+ChatGPT
+  ↓
+endpoint OpenAI do túnel
+  ↓
+tunnel-client rodando no nosso ambiente
+  ↓
+MCP server local em 127.0.0.1:<porta>/mcp
+```
+
+O `tunnel-client` deve rodar dentro da rede que já alcança o MCP server. Em nosso caso, isso significa:
+
+- preferencialmente dentro do Dev Container; ou
+- em um container companheiro na mesma rede Docker; ou
+- no WSL2 host, se ele conseguir alcançar o endpoint interno do MCP server.
+
+O MCP server não precisa ter listener público. Ele pode escutar apenas em localhost, e o túnel faz a ponte outbound para a OpenAI.
+
+Fonte oficial: https://developers.openai.com/api/docs/guides/secure-mcp-tunnels
+
+---
+
+## 13. O formulário do ChatGPT mostrado na imagem
+
+A imagem mostra a criação de um “Novo app” ou conector MCP em `chatgpt.com`.
+
+### Ícone
+
+Opcional. Não afeta a conexão.
+
+### Nome
+
+Use um nome humano e específico. Exemplo:
+
+```text
+Repo DevContainer MCP
+```
+
+ou:
+
+```text
+MCP Server para Repo VS Code
+```
+
+### Descrição
+
+A descrição é importante porque ajuda o modelo a entender quando usar o conector. Ela deve dizer o que o servidor faz e em que contexto deve ser usado.
+
+Exemplo conceitual:
+
+```text
+Conecta ao repositório aberto no VS Code dentro do WSL2 Docker Dev Container. Permite ler arquivos, buscar no código, inspecionar Git, rodar diagnósticos, executar jobs controlados e coordenar integrações locais do projeto.
+```
+
+### URL do servidor MCP
+
+Este é o campo crítico.
+
+Não use:
+
+```text
+http://localhost:3333/mcp
+```
+
+Use uma URL acessível pelo ChatGPT:
+
+```text
+https://<endpoint-do-tunel-ou-host>/mcp
+```
+
+Se for Secure MCP Tunnel, use o endpoint fornecido pela configuração do túnel OpenAI.
+
+### Autenticação
+
+Para desenvolvimento, pode haver modo sem autenticação dependendo do cenário e da configuração disponível. Para uso real, prefira OAuth ou uma combinação com túnel, grants locais e auditoria.
+
+A documentação de autenticação da OpenAI observa que o ChatGPT não apresenta API keys customizadas nem grants machine-to-machine como client credentials; para identificação de cliente, há suporte a mecanismos como mTLS gerenciado pela OpenAI em servidores MCP que validam certificados de cliente.
+
+Fonte oficial: https://developers.openai.com/apps-sdk/build/auth
+
+### Aviso de risco
+
+O aviso existe porque um MCP server pode executar ações reais. No nosso caso, isso é intencional: queremos controle amplo do repo. A resposta correta não é desativar poder; é desenhar poder com auditoria, grants, locks e reversibilidade via Git.
+
+---
+
+## 14. Autenticação e confiança
+
+A conexão tem três camadas de confiança:
+
+### Camada 1 — Transporte
+
+O endpoint deve ser HTTPS quando acessado pelo ChatGPT. Com Secure MCP Tunnel, a conexão externa fica mediada pela infraestrutura da OpenAI e o tráfego do ambiente local sai por conexão outbound.
+
+### Camada 2 — Identidade do cliente
+
+Em produção, use OAuth, mTLS validado, allowlist ou controles equivalentes conforme o tipo de publicação. Evite depender de segredo fixo em header se o cliente não puder apresentá-lo oficialmente.
+
+### Camada 3 — Permissões internas do projeto
+
+Mesmo que o ChatGPT consiga chamar o MCP, o servidor deve decidir o que cada tool pode fazer.
+
+Perfis recomendados:
+
+```text
+observe — leitura, busca, status, logs.
+edit — escrita controlada, patches e arquivos no workspace.
+build — execução de testes, lint, build e diagnósticos.
+ops — instalação, scripts mais amplos, processos e tarefas.
+admin — comandos livres temporários com grant explícito e auditoria.
+```
+
+---
+
+## 15. Como o MCP server deve enxergar o repositório
+
+O MCP server deve ter um `REPO_ROOT` explícito, por exemplo:
+
+```text
+/workspaces/<repo>
+```
+
+Todas as operações de arquivo devem resolver caminhos relativos a esse root. O servidor deve recusar:
+
+- paths absolutos fora do workspace;
+- `..` que escapem do root;
+- leitura acidental de `.ssh`, tokens e secrets;
+- escrita fora do repo;
+- uso não auditado do Docker socket.
+
+O objetivo é ter liberdade ampla dentro do projeto, não liberdade acidental sobre a máquina inteira.
+
+---
+
+## 16. Tools essenciais do MCP server
+
+O primeiro MCP server deve expor poucas tools, mas sólidas.
+
+### Tools de descoberta
+
+```text
+repo_status
+repo_tree
+repo_find
+repo_read_file
+repo_search_text
+```
+
+Essas tools permitem que o ChatGPT entenda o projeto sem alterar nada.
+
+### Tools de Git
+
+```text
+git_status
+git_diff
+git_log
+git_show
+git_branch_info
+```
+
+Essas tools tornam o estado verificável.
+
+### Tools de diagnóstico
+
+```text
+project_doctor
+list_scripts
+read_package_metadata
+```
+
+Essas tools ajudam o modelo a entender como trabalhar no projeto.
+
+---
+
+## 17. Tools intermediárias
+
+Depois da leitura segura, entram escrita e execução controlada.
+
+### Escrita
+
+```text
+write_file
+apply_patch
+create_file
+move_file
+remove_file
+```
+
+Toda escrita deve gerar auditoria e preferencialmente passar por patch/diff.
+
+### Execução
+
+```text
+run_script
+run_test
+run_lint
+run_build
+spawn_job
+get_job_output
+cancel_job
+```
+
+Operações longas devem virar jobs assíncronos, não chamadas bloqueantes sem rastreio.
+
+### Contexto
+
+```text
+context_pack_create
+context_pack_read
+event_log_append
+memory_note_write
+```
+
+Essas tools permitem continuidade entre ChatGPT, terminal, VS Code e outras LLMs.
+
+---
+
+## 18. Tools avançadas
+
+Com a base estável, o MCP server pode expor capacidades mais fortes.
+
+```text
+create_worktree
+switch_task_branch
+run_admin_command
+copilot_session_create
+copilot_send_and_wait
+copilot_steer
+copilot_get_events
+```
+
+`run_admin_command` não deve ser a primeira tool do sistema. Ela é útil, mas deve vir com token local temporário, auditoria e kill switch.
+
+---
+
+## 19. VS Code usando o mesmo MCP server
+
+O VS Code pode usar MCP servers diretamente. Para uso local no Dev Container, prefira `stdio`.
+
+Conceito:
+
+```text
+VS Code Chat/Copilot
+  ↓ stdio
+MCP server Node 24
+  ↓
+repo local
+```
+
+Para HTTP, o VS Code pode conectar a servidores MCP por `type: "http"`; a documentação informa que ele tenta HTTP Stream e faz fallback para SSE quando necessário. Também há suporte a HTTP via Unix socket ou named pipe em cenários específicos.
+
+Fonte oficial: https://code.visualstudio.com/docs/copilot/reference/mcp-configuration
+
+---
+
+## 20. GitHub Copilot SDK 0.3.0 no desenho
+
+O GitHub Copilot SDK 0.3.0 é independente do ChatGPT, mas pode ser integrado ao mesmo ambiente.
+
+Ele pode atuar de duas maneiras:
+
+1. Como consumidor do nosso MCP server local.
+2. Como runtime local de agente por meio de Copilot CLI headless.
+
+A documentação do GitHub diz que o Copilot SDK pode integrar MCP servers que rodam como processos separados e expõem tools. Ela também distingue servidores locais/stdio e HTTP/SSE.
+
+Fonte oficial: https://docs.github.com/en/copilot/how-tos/copilot-sdk/use-copilot-sdk/mcp-servers
+
+As release notes do SDK 0.3.0 indicam mudanças importantes: a terminologia de configuração MCP foi alinhada para `stdio` e `http`, e o vocabulário de permissões foi refinado para resultados como `approve-once`, `approve-for-session` e `approve-for-location`.
+
+Fonte oficial: https://github.com/github/copilot-sdk/releases
+
+---
+
+## 21. Copilot CLI headless + `cliUrl`
+
+O modo mais robusto para integrar Copilot local é rodar o Copilot CLI em modo headless dentro do Dev Container ou em container companheiro.
+
+A ideia:
+
+```text
+Copilot CLI headless
+  ↑ TCP / cliUrl
+Copilot SDK Node 24
+  ↑ MCP tool
+ChatGPT ou outro orquestrador
+```
+
+Segundo a documentação do GitHub, nesse modo a CLI roda como servidor persistente; o backend se conecta por TCP usando `cliUrl`; múltiplos clientes SDK podem compartilhar o mesmo servidor.
+
+Fonte oficial: https://docs.github.com/en/copilot/how-tos/copilot-sdk/set-up-copilot-sdk/backend-services
+
+Isso não substitui o MCP server. Ele complementa:
+
+```text
+ChatGPT
+  ↓
+MCP server
+  ↓
+Copilot Bridge
+  ↓
+Copilot SDK
+  ↓
+Copilot CLI headless
+  ↓
+repo
+```
+
+O ChatGPT continua chamando tools MCP. O Copilot local pode ser acionado como executor especializado.
+
+---
+
+## 22. Como outras LLMs entram no sistema
+
+Outras LLMs ou agentes podem usar o mesmo projeto se suportarem MCP ou se forem conectadas por uma ponte própria.
+
+Modelos de conexão:
+
+```text
+LLM local → stdio → MCP server
+LLM remota → HTTPS /mcp → MCP server
+LLM remota → túnel → MCP server
+Copilot SDK → stdio/http → MCP server
+```
+
+A vantagem do MCP é evitar criar uma integração diferente para cada LLM. O repositório expõe um contrato comum; cada cliente usa o transporte compatível.
+
+---
+
+## 23. Memória operacional compartilhada
+
+A conversa do ChatGPT pode ser efêmera. O projeto não deve ser.
+
+Crie uma pasta de estado operacional:
+
+```text
+.ai/
+  context-pack.md
+  tasks/
+  logs/
+  jobs/
+  audit/
+  decisions/
+```
+
+Essa pasta serve para:
+
+- registrar decisões;
+- guardar estado de tarefas;
+- permitir retomada por outra LLM;
+- tornar operações auditáveis;
+- reduzir dependência da memória da conversa;
+- permitir que terminal, ChatGPT, VS Code e Copilot compartilhem contexto.
+
+Para humanos e LLMs, o arquivo mais importante é o `context-pack.md`, que deve explicar o estado atual do projeto, próximos passos, comandos recentes, diffs relevantes e decisões tomadas.
+
+---
+
+## 24. Segurança sem amputar liberdade
+
+O objetivo não é limitar o sistema a leitura. O objetivo é permitir controle amplo de maneira rastreável.
+
+Princípios:
+
+1. O repo é o limite operacional padrão.
+2. Escritas devem gerar diff.
+3. Comandos devem gerar job log.
+4. Operações destrutivas exigem grant explícito.
+5. Secrets devem ser protegidos por denylist e detecção.
+6. Docker socket não deve ser exposto por padrão.
+7. Ações devem ser reversíveis por Git quando possível.
+8. Tool descriptions devem ser claras para evitar uso incorreto pelo modelo.
+9. Prompt injection em arquivos do repo deve ser tratado como dado não confiável.
+10. Liberdade máxima deve ser temporária, auditada e revogável.
+
+---
+
+## 25. Fluxo de implementação recomendado
+
+### Fase 1 — Ambiente
+
+- Repo no filesystem WSL2.
+- VS Code aberto em WSL2.
+- Dev Container funcional.
+- Node 24 dentro do container.
+- Scripts básicos do projeto funcionando.
+
+### Fase 2 — MCP local de leitura
+
+- Criar MCP server Node 24.
+- Rodar via `stdio` dentro do Dev Container.
+- Expor tools de leitura e Git.
+- Testar no VS Code ou MCP Inspector.
+
+### Fase 3 — Project Control Plane
+
+- Criar camada de paths, auditoria e logs.
+- Criar `.ai/`.
+- Criar `project_doctor`.
+- Criar tools de diagnóstico.
+
+### Fase 4 — Streamable HTTP `/mcp`
+
+- Adicionar adaptador HTTP.
+- Bind local em `127.0.0.1` para desenvolvimento.
+- Validar `Origin` quando aplicável.
+- Preparar autenticação ou proteção por túnel.
+
+### Fase 5 — Secure MCP Tunnel
+
+- Rodar o `tunnel-client` onde ele alcança o MCP server.
+- Apontar o túnel para o endpoint local `/mcp`.
+- Usar a URL do túnel no formulário do ChatGPT.
+
+### Fase 6 — ChatGPT
+
+- Criar o conector no ChatGPT.
+- Preencher nome, descrição, URL `/mcp` e autenticação.
+- Confirmar que as tools aparecem.
+- Testar leitura do repo.
+- Depois testar escrita controlada.
+
+### Fase 7 — Copilot SDK 0.3.0
+
+- Integrar Copilot SDK como consumidor local.
+- Opcionalmente iniciar Copilot CLI headless.
+- Conectar via `cliUrl`.
+- Expor tools MCP de delegação ao Copilot local.
+
+### Fase 8 — Operação avançada
+
+- Jobs assíncronos.
+- Worktrees.
+- Locks.
+- Event bus.
+- Grants temporários.
+- Admin command auditado.
+
+---
+
+## 26. Smoke tests
+
+Antes de conectar o ChatGPT, valide localmente:
+
+```text
+1. O MCP server sobe no Dev Container.
+2. Ele enxerga /workspaces/<repo>.
+3. repo_status retorna o branch correto.
+4. repo_read_file lê um arquivo conhecido.
+5. git_diff retorna o diff atual.
+6. project_doctor identifica Node 24, Git e scripts.
+7. O endpoint /mcp responde localmente.
+8. O túnel consegue alcançar /mcp.
+9. O ChatGPT lista as tools após criar o conector.
+10. Uma chamada simples de leitura funciona na conversa.
+```
+
+Depois:
+
+```text
+11. apply_patch cria um diff esperado.
+12. run_test cria job log.
+13. get_job_output retorna logs.
+14. cancel_job interrompe processo longo.
+15. audit log registra cada ação.
+```
+
+---
+
+## 27. Diagnóstico de falhas comuns
+
+### ChatGPT não conecta
+
+Prováveis causas:
+
+- URL não é HTTPS.
+- URL aponta para localhost.
+- `/mcp` não está exposto corretamente.
+- Tunnel client não está rodando.
+- MCP server caiu.
+- Autenticação não está compatível.
+
+### Tools não aparecem
+
+Prováveis causas:
+
+- O servidor não respondeu ao handshake MCP.
+- Tool schema inválido.
+- Descrição ou metadados quebrados.
+- Endpoint errado.
+- Servidor responde HTML/erro em vez de JSON-RPC/MCP.
+
+### VS Code funciona, ChatGPT não
+
+Provável causa:
+
+- VS Code está usando `stdio`, mas ChatGPT precisa de HTTP/túnel.
+
+### ChatGPT funciona, mas não vê arquivos certos
+
+Prováveis causas:
+
+- MCP server rodando fora do Dev Container.
+- `REPO_ROOT` aponta para caminho errado.
+- Repo está no Windows filesystem e não no WSL2.
+- Container companheiro não montou o mesmo workspace.
+
+### Performance ruim
+
+Prováveis causas:
+
+- Repo em `C:\`.
+- `node_modules` em bind mount lento.
+- Busca textual sem índice.
+- Tools retornando contexto excessivo.
+- Jobs longos sendo executados de modo síncrono.
+
+A documentação do VS Code recomenda volumes nomeados para diretórios de alta escrita, como `node_modules`, caches e build outputs, quando performance de bind mount é um problema.
+
+Fonte oficial: https://code.visualstudio.com/remote/advancedcontainers/improve-performance
+
+---
+
+## 28. Decisões canônicas
+
+1. O repo deve ficar no filesystem WSL2.
+2. O VS Code deve abrir o repo em Dev Container.
+3. O MCP server deve rodar no mesmo ambiente do repo.
+4. Node 24 é o runtime padrão.
+5. `stdio` é o transporte local principal.
+6. Streamable HTTP `/mcp` é o transporte remoto principal.
+7. SSE legado é apenas compatibilidade.
+8. ChatGPT não usa `localhost`; usa HTTPS ou Secure MCP Tunnel.
+9. O formulário do ChatGPT recebe a URL pública/tunelada `/mcp`.
+10. O MCP server deve começar por leitura e Git antes de escrita e execução.
+11. Escrita e execução devem ser auditadas.
+12. GitHub Copilot SDK 0.3.0 entra como camada local complementar.
+13. Copilot CLI headless + `cliUrl` é o attach robusto para backend local.
+14. `.ai/` é a memória operacional compartilhada.
+15. Liberdade ampla exige logs, grants, locks e reversibilidade.
+
+---
+
+## 29. Fontes oficiais
+
+### OpenAI / ChatGPT / MCP
+
+- Connect from ChatGPT — Apps SDK:
+  https://developers.openai.com/apps-sdk/deploy/connect-chatgpt
+
+- Build your MCP server — Apps SDK:
+  https://developers.openai.com/apps-sdk/build/mcp-server
+
+- Secure MCP Tunnel — OpenAI API:
+  https://developers.openai.com/api/docs/guides/secure-mcp-tunnels
+
+- MCP and Connectors — OpenAI API:
+  https://developers.openai.com/api/docs/guides/tools-connectors-mcp
+
+- Authentication — Apps SDK:
+  https://developers.openai.com/apps-sdk/build/auth
+
+### Model Context Protocol
+
+- MCP specification — transports:
+  https://modelcontextprotocol.io/specification/2025-03-26/basic/transports
+
+- MCP specification index:
+  https://modelcontextprotocol.io/specification
+
+### VS Code / Dev Containers / WSL2
+
+- Add and manage MCP servers in VS Code:
+  https://code.visualstudio.com/docs/copilot/customization/mcp-servers
+
+- MCP configuration reference — VS Code:
+  https://code.visualstudio.com/docs/copilot/reference/mcp-configuration
+
+- Developing inside a Container — VS Code:
+  https://code.visualstudio.com/docs/devcontainers/containers
+
+- Improve Dev Container performance — VS Code:
+  https://code.visualstudio.com/remote/advancedcontainers/improve-performance
+
+- Dev Containers on Windows with WSL2 — Microsoft Learn:
+  https://learn.microsoft.com/en-us/windows/dev-environment/docker/dev-containers
+
+### GitHub Copilot SDK / CLI
+
+- Copilot SDK backend services:
+  https://docs.github.com/en/copilot/how-tos/copilot-sdk/set-up-copilot-sdk/backend-services
+
+- Copilot SDK with MCP servers:
+  https://docs.github.com/en/copilot/how-tos/copilot-sdk/use-copilot-sdk/mcp-servers
+
+- Copilot SDK releases:
+  https://github.com/github/copilot-sdk/releases
+
+- About GitHub Copilot CLI:
+  https://docs.github.com/copilot/concepts/agents/about-copilot-cli
+
+### Node.js
+
+- Node.js documentation:
+  https://nodejs.org/docs/latest-v24.x/api/
+
+- Node.js Permission Model:
+  https://nodejs.org/docs/latest-v24.x/api/permissions.html
+
+---
+
+## 30. Conclusão
+
+A conexão correta entre ChatGPT e o nosso VS Code em WSL2 Docker Dev Container não é uma conexão visual com o editor, nem uma tentativa de controlar a tela do terminal. É uma conexão protocolar.
+
+O ChatGPT se conecta a um endpoint MCP. Esse endpoint chega a um MCP server Node 24 rodando dentro do Dev Container. Esse servidor opera o repositório real, com tools bem definidas, logs, grants, Git, jobs e memória compartilhada.
+
+O desenho final é simples na superfície e forte internamente:
+
+```text
+ChatGPT
+  ↓
+Connector MCP em /mcp
+  ↓
+Secure MCP Tunnel ou HTTPS
+  ↓
+MCP server Node 24 no Dev Container
+  ↓
+Project Control Plane
+  ↓
+Repo real do VS Code
+```
+
+Para o humano, isso significa poder pedir ao ChatGPT para investigar, editar, testar, revisar e coordenar o projeto. Para outras LLMs, significa uma interface padronizada. Para o sistema, significa que o projeto deixa de depender de uma conversa específica e passa a ter uma superfície operacional própria.
+
+A implementação deve começar pequena: leitura, Git e diagnóstico. Em seguida, escrita controlada. Depois, jobs. Por fim, Copilot SDK 0.3.0, Copilot CLI headless, worktrees, event bus e multiagente.
+
+O resultado esperado é um ambiente no qual o ChatGPT e outros agentes não apenas “comentam” sobre o projeto, mas conseguem operar o projeto dentro do mesmo ambiente real em que ele é desenvolvido.

--- a/AUDITORIA_TOOLS_READ_COMPLETA.md
+++ b/AUDITORIA_TOOLS_READ_COMPLETA.md
@@ -1,0 +1,425 @@
+# Auditoria Profunda — Tools de Read (`src/copilot/tools/file/`)
+
+**Gerado em**: 2026-05-22
+**Escopo**: `src/copilot/tools/file/read/`, `src/copilot/tools/file/read-tools.js`, IO associada
+**Status**: Análise completa — relatório gerado por leitura direta dos arquivos fonte
+**Não alterações aplicadas** — conforme solicitado pelo usuário.
+
+---
+
+## 1. Situação Atual
+
+### 1.1 Arquitetura geral
+
+```
+src/copilot/tools/file/
+├── read/
+│   ├── index.js                       ← barrel interno (4 exports)
+│   ├── read-file-content.js           ← tool principal (419 linhas)
+│   ├── metadata.js                    ← builder de metadados canônicos
+│   ├── window.js                      ← normalizadores de cursor/janela
+│   └── feedback.js                    ← feedback estruturado de falhas
+├── read-tools.js                      ← barrel canônico: readContent + listDir + diff
+├── index-tools.js                     ← índice L2
+├── scope-tools.js                     ← escopo LLM-B
+├── file-tools.js                      ← agregação do array fileTools
+├── write-tools.js                     ← ferramentas de escrita
+└── shared.js                          ← política, constants, helpers (296 linhas)
+```
+
+**Submódulos de infra suportando a cadeia de leitura:**
+
+```
+src/copilot/tools/infra/
+├── tool-factory.js                    ← buildTool (construção de tools, permissões)
+├── tool-feedback.js                   ← createToolFailureResult (8 categorias)
+└── logger.js                          ← log() com injeção opcional
+
+src/copilot/infra/public/
+├── io.js                              ← facade barrel-first: readText, readBytes, diffText, scanDirectory
+├── buffer.js                          ← helpers de Buffer (truncateUtf8String, utf8ByteLength)
+├── policy.js                          ← hasNullByte, isPathInsideWorkspace
+├── cache.js                           ← getIoCacheStats
+└── indexing.js                        ← buildIoIndexForDirectory, searchIoIndex
+
+src/copilot/infra/io/fs/
+├── read-text.js                       ← readTextFileSnapshot (acíclico, sem cache)
+├── read-bytes.js                      ← readBytesFileSnapshot (binário, sem cache)
+└── index.js                           ← barrel
+```
+
+### 1.2 Fluxo canônico de `read_file_content`
+
+```
+read_file_content (tool)
+  │
+  ├── validatePath(filePath, { mode: 'read' })
+  │     └── evaluateIoPathPolicyAsync  ← core + null byte guard
+  ├── parseReadCursor(cursor)          ← window.js
+  │
+  ├── [base64 branch]
+  │     └── readBytes(filePath)
+  │           └── truncateBuffer(source, maxBytes)   ← shared → buffer
+  │
+  ├── [utf8 branch, readStrategy=cached]
+  │     └── readText(filePath, { startLine, endLine })
+  │           └── cache L1
+  │           └── warmReadThroughContext (se >= 1KB)
+  │
+  ├── [utf8 branch, readStrategy=stream]
+  │     └── readTextChunks(filePath, { startLine, endLine, chunkLines: 200 })
+  │
+  ├── sanitizeIoTextOutput(text)         ← core: remove segredos
+  ├── truncateUtf8Text(sanitized, maxBytes) ← injeta mensagem de policy no stream
+  ├── buildReadFileMetadata(stats, input)   ← metadata.js
+  └── withIoMeta(result, ioMeta)          ← io.* no topo da resposta
+```
+
+### 1.3 Pontos fortes da implementação atual
+
+| Ponto | Evidência |
+|-------|-----------|
+| Separação semântica clara | 5 módulos em `read/` com responsabilidades distintas |
+| Feedback estruturado | 6 códigos de erro, `ToolFailureResult` com schema JSON-LD |
+| Política de saída | `FILE_TOOLS_OUTPUT_POLICY` com ENV overrides (4 limites) |
+| Cache L1 | hitRate via `getIoCacheStats()`, `cacheFingerprintStrategy` em metadata |
+| Cursor/janela bem definido | `parseReadCursor`, `nextLineCursor`, `applyEntryWindow` |
+| Base64 pathway completo | byte-cursor, maxBytes, rawReturnedBytes, nextCursor |
+| Sanitização integrada | `sanitizeIoTextOutput` + `SECRET_KEY_RE` no feedback |
+| Logging com injeção | `setToolsLogger` / fallback `console.*` |
+| Testes unitários | 520 linhas, 13 casos positivos cobrindo readContent, listDirectory e diffFiles |
+
+---
+
+## 2. Bugs Encontrados
+
+### BUG-01 — Variável `resolvedReadStrategy` pode estar como TODO pendente
+
+**Arquivo**: `src/copilot/tools/file/read/read-file-content.js`
+**Linha**: ~138
+
+Na leitura visual do arquivo (419 linhas, duas janelas), aparece uma referência a `normalizeReadStrategy` como placeholder — indicando que a variável `resolvedReadStrategy` ainda pode não estar definida antes de todas as branches do `if`. O fluxo base64 não a usa (correto), mas branches de validação podem tentar acessá-la.
+
+**Severidade**: Média — `ReferenceError` em validações intermediárias se o pending não for resolvido.
+
+**Fix proposta**:
+```js
+// Mover para o topo do handler:
+const resolvedEncoding = encoding ?? 'utf8';
+const resolvedReadStrategy = readStrategy ?? 'cached'; // ← linha única, depois de parameters
+```
+
+---
+
+### BUG-02 — `receivedParameters` carrega valores `undefined` para params omitidos
+
+**Arquivo**: `src/copilot/tools/file/read/read-file-content.js`, linha ~95
+
+```js
+const receivedParameters = {
+    path: filePath,
+    startLine,   // undefined quando omitido
+    endLine,     // undefined quando omitido
+    cursor,      // undefined quando omitido
+    // ...
+};
+```
+
+Em falhas, `createReadFileFailure` serializa esse objeto para `receivedParameters` no `details`. Valores `undefined` poluem o JSON de saída sem adicionar informação útil. Não quebra nada, mas aumenta ruído em logs.
+
+**Severidade**: Baixa — ruído em logs.
+
+---
+
+### BUG-03 — `validatePath` usa `mode='write'` como default, mais restritivo que o esperado
+
+**Arquivo**: `src/copilot/tools/file/shared.js`, linha ~169
+
+```js
+const mode = opts?.mode ?? 'write';  // default é write
+```
+
+Isto é proposital (defense-in-depth): se um consumidor esquecer `{ mode: 'read' }`, a política de escrita bloqueia antes de bloquear a de leitura. O tradeoff é que erros de programação resultam em `ERR_READ_PATH_INVALID` (category: `policy-denied`) em vez de `not-found` ou `invalid-parameters` — confundindo o diagnóstico.
+
+**Severidade**: Baixa — intencional, só precisa de documentação explícita no JSDoc.
+
+---
+
+### BUG-04 — `nextLineCursor` não valida EOF quando `totalLinesKnown=false`
+
+**Arquivo**: `src/copilot/tools/file/read/window.js`, linha ~52
+
+```js
+export function nextLineCursor(returnedLines, totalLines, totalLinesKnown) {
+    if (returnedLines.end < returnedLines.start) return null;
+    if (totalLinesKnown && Number.isFinite(totalLines) && returnedLines.end >= Number(totalLines)) return null;
+    // Quando totalLinesKnown=false: retorna String(end+1) sem saber se é o fim real
+    return String(returnedLines.end + 1);
+}
+```
+
+Quando `totalLinesKnown=false` (branch `stream` onde `totalLines` é `undefined`), a função não sabe o tamanho do arquivo e retorna um cursor que pode estar além do fim real. O downstream valida e retorna erro, mas o cursor enganoso causa uma chamada extra.
+
+**Severidade**: Baixa — recuperável, mas ineficiente.
+
+---
+
+### BUG-05 — Truncamento injeta mensagem de policy no próprio stream de saída
+
+**Arquivo**: `src/copilot/tools/file/shared.js`, linha ~225
+
+```js
+return {
+    text: `${truncated.text}${suffix}`,
+    truncated: true,
+    originalBytes: truncated.originalBytes,
+    limitBytes: truncated.limitBytes,
+};
+```
+
+O `suffix` é a mensagem da policy diretamente concatenada ao conteúdo. Para consumers que reconstroem o EOF (JSON, YAML, scripts), o notice corrompe o arquivo e o reconstrução é impossível.
+
+**Severidade**: Média — afeta workflows de leitura-edição-gravação incremental.
+
+---
+
+## 3. Gaps de Arquitetura
+
+### GAP-01 — Barril duplicado em `read/` (4 exports vs. 3 tools canônicas)
+
+```
+read/index.js    ← 4 exports: readFileContentTool + window/utils
+read-tools.js    ← 3 tools: readContent + listDirectory + diffFiles
+```
+
+Não há um arquivo canônico único que una todas as responsabilidades da ferramenta — gerando dois caminhos de descoberta e possível importação cruzada acidental.
+
+---
+
+### GAP-02 — IO dual-path não tem regra de uso documentada
+
+`readTextFileSnapshot` (sem cache) e `readText` (com cache) fazem a mesma coisa por caminhos diferentes. O dual-path existe porque parser/index-store precisam sair da facade — mas essa exceção não tem contrato nem lint rule; qualquer módulo novo pode escolher aleatoriamente qual caminho usar.
+
+---
+
+### GAP-03 — `withSkipPermission` policy espalhada em comentários
+
+O `withSkipPermission` é aplicado em `read-tools.js` e documentado em comentário do `tool-factory.js` (fix TF-01), mas não há regra única em um arquivo de arquitetura ou convenções. Qualquer ferramenta de leitura nova precisa descobrir essa política por leitura de arquivos existentes.
+
+---
+
+### GAP-04 — Logger injetado sem ponto de injeção canônico
+
+`setToolsLogger()` deve ser chamado por `agent/` ou `server/` mas não há ponto canônico de boot documentado, nem TODO ou lint que garanta a chamada antes do primeiro `log()`. Na prática, o fallback `console.*` é usado em muitos ambientes.
+
+---
+
+### GAP-05 — Testes não cobrem branches de erro
+
+`test_read_tools.spec.js` tem 13 testes positivos, zero testes que exijam `expect(r.success).toBe(false)`. Os 6 códigos de erro canônicos de `feedback.js` não têm cobertura de teste.
+
+---
+
+### GAP-06 — `readStrategy: 'stream'` não tem limite de buffer default documentado
+
+O parâmetro `streamHighWaterMark` tem min 1024, max 16MB, mas não há um default documentado no schema (é `Node/fs padrão`). Em ambientes com memória limitada, um valor default implícito de 16MB pode causar surpresa.
+
+---
+
+## 4. Oportunidades de Upgrade
+
+### UPGRADE-01 — Centralizar `resolvedReadStrategy` antes de qualquer branch (BUG-01 fix + prevenção)
+
+Mover `const resolvedEncoding` e `const resolvedReadStrategy` para o topo do handler, antes de qualquer condicional. Adicionar `/* istanbul ignore next */` onde a branch é teoricamente inalcançável.
+
+---
+
+### UPGRADE-02 — Limpar receivedParameters em falhas (BUG-02 fix)
+
+Adicionar helper em `feedback.js`:
+```js
+function cleanParams(params) {
+    const out = { ...params };
+    for (const [k, v] of Object.entries(out)) {
+        if (v === undefined) delete out[k];
+    }
+    return out;
+}
+```
+
+---
+
+### UPGRADE-03 — Truncamento não-destrutivo (BUG-05 fix)
+
+Retornar `notice` separado em `truncateUtf8Text`:
+```js
+// Nova assinatura:
+truncateUtf8Text(text, maxBytes, notice) → { text, truncated, originalBytes, limitBytes, notice }
+
+// Uso no handler:
+const { text: content, notice, truncated } = truncateUtf8Text(...);
+return { ...result, content, truncated, ...(notice ? { notice } : {}) };
+```
+
+Consumidores que precisam do aviso concatenado podem fazer `content + notice` explicitamente.
+
+---
+
+### UPGRADE-04 — Documentar dual-path IO no JSDoc (GAP-02)
+
+Adicionar em `readTextFileSnapshot` / `readBytesFileSnapshot`:
+```js
+/**
+ * NOTA: Esta função bypassa a facade io-engine (sem cache, sem telemetria).
+ * Use-a apenas em: parser de índice, index-store, hooks de boot.
+ * Para tools de usuário, use `readText()` / `readBytes()` de infra/public/io.js.
+ */
+```
+
+---
+
+### UPGRADE-05 — Único barrel canônico para ferramentas de leitura (GAP-01)
+
+Fazer `read-tools.js` ser o único barrel canônico. `read/index.js` vira compat shim com warning de remoção futura:
+```js
+/** @deprecated Use `read-tools.js` directly. Remove em próxima major. */
+export { readFileContentTool } from '../read-tools.js';
+```
+
+---
+
+### UPGRADE-06 — Ponto de injeção de logger no boot (GAP-04)
+
+Adicionar `initializeToolsLogger(logFn)` em `src/copilot/boot/logger-setup.js` chamado no início do `src/main.js`:
+```js
+import { setToolsLogger } from '#copilot/tools/infra/logger';
+import { createStructuredLogger } from '#copilot/observability/logger';
+
+const structuredLogger = createStructuredLogger({ service: 'tools' });
+setToolsLogger(structructuredLogger);
+```
+
+---
+
+### UPGRADE-07 — Testes de erro para 6 códigos de falha de read (GAP-05)
+
+6 testes adicionais em `test_read_tools.spec.js`:
+| Código | Cenário |
+|--------|---------|
+| ERR_READ_PATH_INVALID | caminho fora do workspace |
+| ERR_READ_CURSOR_INVALID | cursor = -1, cursor = 'abc' |
+| ERR_READ_LINE_WINDOW_INVALID | endLine < startLine |
+| ERR_READ_DIRECTORY | path aponta para diretório |
+| ERR_READ_BINARY_LINE_WINDOW | startLine com encoding=base64 |
+| ERRO genérico | emulando erro de disco (ENOENT temporário) |
+
+---
+
+### UPGRADE-08 — Telemetria de cache hit-rate por tool
+
+`includeCacheStats` já retorna `{ hits, misses, hashRevalidations, hashRevalidationHits }`, mas esses dados não são agregados em lugar nenhum. Proposta:
+- collector em `observability/collectors/tool-cache-stats.js`
+- métricas `tool_cache_hits_total`, `tool_cache_misses_total`, `tool_cache_hit_ratio` por tool
+- disponível no dashboard de observability
+
+---
+
+## 5. Proposta de Situação Ideal
+
+### Princípios
+
+1. **Um único barrel canônico** por subdomínio de tools
+2. **IO dual-path com regra explícita** — facade para tools; snapshot para parser/index
+3. **Truncamento não destrutivo** — notice separado do conteúdo
+4. **Erros 100% cobertos por testes** — toda branch de falha tem teste
+5. **Logger injetado no boot** — sem fallback `console.*` em produção
+6. **Telemetria agregada por tool** — cache hit-rate no dashboard
+
+### Estado alvo (resumo)
+
+```
+src/copilot/tools/file/read-tools.js   ← único barrel canônico
+├── readFileContentTool               ← handler limpo: resolved* no topo, params limpos
+├── listDirectoryTool
+├── diffFilesTool                     ← truncamento não-destrutivo
+└── __utilities__                     ← nextLineCursor, normalize*, parseReadCursor, applyEntry*
+
+src/copilot/tools/file/read/          ← compat shims apenas (lazy deprecation)
+
+tests/unit/copilot/tools/file/test_read_tools.spec.js
+├── 13 testes positivos (existentes)
+└── 8+ testes de erro (novo)
+```
+
+---
+
+## 6. Roadmap
+
+### FASE 1 — Estabilização (curto prazo, sem mudança de comportamento)
+
+| Subfase | Trabalho | Critério de saída |
+|---------|----------|-------------------|
+| 1.1 | Documentar dual-path IO no JSDod de `readTextFileSnapshot`/`readBytesFileSnapshot` | Documentação atualizada + PR |
+| 1.2 | Documentar `validatePath` default-mode tradeoff em JSDoc | `shared.js` JSDoc linha ~165 atualizado |
+| 1.3 | Documentar `nextLineCursor` guard em comentário | `window.js` comentário adicionado |
+| 1.4 | Adicionar `initializeToolsLogger` no boot/boot wiring | `setToolsLogger` chamado sem erros |
+| 1.5 | Adicionar 5 testes de erro para read-file-content | 5 testes verdes em `test_read_tools.spec.js` |
+
+---
+
+### FASE 2 — Consolidação arquitetural (médio prazo)
+
+| Subfase | Trabalho | Critério de saída |
+|---------|----------|-------------------|
+| 2.1 | Fundir `read/index.js` em `read-tools.js` (GAP-01) | `read-tools.js` exports tudo; `read/index.js` vira compat shim |
+| 2.2 | Truncamento não-destrutivo (BUG-05) | `truncateUtf8Text` retorna `{ content, notice }`; handlers atualizados |
+| 2.3 | `receivedParameters` limpos (BUG-02) | `cleanReceivedParameters()` adicionado + falhas sem `undefined` |
+| 2.4 | Lint rule `io-snapshot-only` (GAP-02) | ESLint custom rule ativa |
+| 2.5 | Documentar `withSkipPermission` policy em local único (GAP-03) | `DOCUMENTAÇÃO/ARQUITETURA/TOOLS-README.md` criado/atualizado |
+
+---
+
+### FASE 3 — Observabilidade e evolução (longo prazo)
+
+| Subfase | Trabalho | Critério de saída |
+|---------|----------|-------------------|
+| 3.1 | Telemetry cache hit-rate por tool | `tool-cache-stats` collector ativo |
+| 3.2 | Testes de concorrência: duas leituras simultâneas | Mesmo `cacheFingerprintStrategy`, race-free |
+| 3.3 | Stress test stream em arquivo binário >10MB | 0 bytes perdidos, paginação correta |
+| 3.4 | Smoke test canônico no CI | `npm run test:read-tools:smoke` passa em todo PR |
+| 3.5 | `selfDescription` no JSDoc para auto-programação LLM-B | Tool descritiva sem leitura externa |
+
+---
+
+## 7. Matriz de Priorização
+
+| Bug/Gap | Fase 1 | Fase 2 | Fase 3 |
+|---------|--------|--------|--------|
+| BUG-01 `resolvedReadStrategy` | 1.3 | 2.1 | — |
+| BUG-02 `receivedParameters` limpos | — | 2.3 | — |
+| BUG-03 `validatePath` default | 1.2 | — | — |
+| BUG-04 `nextLineCursor` EOF | 1.3 | — | — |
+| BUG-05 truncamento destrutivo | — | 2.2 | — |
+| GAP-01 barrels duplicados | — | 2.1 | — |
+| GAP-02 IO dual-path | 1.1 | 2.4 | — |
+| GAP-03 withSkipPermission espalhado | — | 2.5 | — |
+| GAP-04 logger injetado sem boot point | 1.4 | — | — |
+| GAP-05 testes de erro ausentes | 1.5 | — | — |
+| UPGRADE-01 README TOOLS-* | — | 2.5 | — |
+| UPGRADE-02 hit-rate telemetry | — | — | 3.1 |
+
+---
+
+## 8. Avaliação de Risco
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|-------|---------------|---------|-----------|
+| BUG-05 corrompe workflows de edição incremental | Média | Alto | Fase 2.2 — truncamento não-destrutivo |
+| GAP-02 causa duplicação de caminho IO em novos módulos | Alta | Médio | Lint rule em Fase 2.4 |
+| BUG-01 causa erro de runtime em validações | Baixa | Alto | Fase 1.3 + fix em Fase 2.1 |
+| GAP-05 deixa regressões de erro não detectadas | Alta | Médio | Fase 1.5 — testes de erro imediatos |
+| GAP-04 logger não injetado em produção | Média | Baixo | Fase 1.4 — boot wiring |
+
+---
+
+*Relatório gerado exclusivamente por leitura direta dos arquivos fonte. Nenhuma alteração de código foi aplicada.*

--- a/DOCUMENTAÇÃO/# Guia focado — Conexão do ChatGPT ao VS.md
+++ b/DOCUMENTAÇÃO/# Guia focado — Conexão do ChatGPT ao VS.md
@@ -1,0 +1,995 @@
+# Guia focado — Conexão do ChatGPT ao VS Code em WSL2 Docker Dev Container via MCP
+
+**Versão:** 2.0 — guia focado de conexão
+**Ambiente-alvo:** Windows + WSL2 + Docker Desktop + VS Code Dev Containers + Node 24 + GitHub Copilot SDK 0.3.0
+**Objetivo:** permitir que o ChatGPT em `https://chatgpt.com/`, e também outras LLMs compatíveis, conectem-se ao repositório real aberto no VS Code dentro de um Dev Container, por meio de um MCP server local controlado, rápido, auditável e com ampla capacidade operacional.
+
+---
+
+## Índice
+
+1. Propósito do documento
+2. A ideia central em uma página
+3. Vocabulário mínimo
+4. O que significa “conectar o ChatGPT ao VS Code”
+5. Topologia recomendada
+6. Papel do WSL2
+7. Papel do Docker Dev Container
+8. Papel do Node 24
+9. Papel do MCP server
+10. Transportes: stdio, Streamable HTTP e SSE
+11. Por que o ChatGPT precisa de `/mcp` via HTTPS ou túnel
+12. Secure MCP Tunnel
+13. O formulário do ChatGPT mostrado na imagem
+14. Autenticação e confiança
+15. Como o MCP server deve enxergar o repositório
+16. Tools essenciais do MCP server
+17. Tools intermediárias
+18. Tools avançadas
+19. VS Code usando o mesmo MCP server
+20. GitHub Copilot SDK 0.3.0 no desenho
+21. Copilot CLI headless + `cliUrl`
+22. Como outras LLMs entram no sistema
+23. Memória operacional compartilhada
+24. Segurança sem amputar liberdade
+25. Fluxo de implementação recomendado
+26. Smoke tests
+27. Diagnóstico de falhas comuns
+28. Decisões canônicas
+29. Fontes oficiais
+30. Conclusão
+
+---
+
+## 1. Propósito do documento
+
+Este documento concentra-se em uma única pergunta prática:
+
+> Como fazer o ChatGPT, pela interface `chatgpt.com`, conectar-se ao nosso repositório real aberto no VS Code, dentro de WSL2 + Docker Dev Container, e operar esse projeto por meio de um MCP server escrito para Node 24?
+
+O foco aqui não é explicar toda a plataforma de agentes, nem fornecer código completo. O foco é a conexão: o caminho físico, lógico e protocolar entre a conversa no ChatGPT e o ambiente real de desenvolvimento.
+
+O documento também considera o GitHub Copilot SDK 0.3.0, não como substituto do MCP, mas como uma camada local adicional para orquestração, execução assistida e possível delegação a um agente Copilot rodando dentro do mesmo ambiente do projeto.
+
+---
+
+## 2. A ideia central em uma página
+
+O ChatGPT não acessa diretamente o seu VS Code, seu terminal, seu `localhost` do Windows ou seu filesystem. O ChatGPT acessa **um servidor MCP**.
+
+Esse MCP server, por sua vez, roda no mesmo ambiente onde o projeto realmente vive: o Dev Container do VS Code, dentro do WSL2/Docker.
+
+A topologia ideal é:
+
+```text
+ChatGPT em chatgpt.com
+  ↓ conector MCP
+Endpoint HTTPS /mcp ou Secure MCP Tunnel
+  ↓
+MCP server Node 24 dentro do Dev Container
+  ↓
+Project Control Plane
+  ↓
+/workspaces/<repo> — o repositório real do VS Code
+```
+
+Para uso local, o VS Code e outros clientes dentro do container podem usar `stdio`. Para o ChatGPT remoto, o transporte correto é Streamable HTTP em `/mcp`, exposto por HTTPS ou por Secure MCP Tunnel.
+
+A documentação oficial do ChatGPT Apps SDK indica que o conector deve receber a URL pública do endpoint `/mcp` do servidor. Para desenvolvimento local, essa URL precisa ser alcançável por HTTPS, normalmente via túnel.
+Fonte oficial: https://developers.openai.com/apps-sdk/deploy/connect-chatgpt
+
+---
+
+## 3. Vocabulário mínimo
+
+### ChatGPT
+
+A interface em `https://chatgpt.com/`. Neste documento, “ChatGPT” significa esta superfície remota da OpenAI, capaz de chamar tools por meio de um app/conector MCP.
+
+### VS Code
+
+O editor usado pelo humano. Ele está conectado ao ambiente WSL2 e reabre o projeto dentro de um Dev Container.
+
+### WSL2
+
+O ambiente Linux real dentro do Windows. Deve conter o clone do projeto para evitar a lentidão do filesystem `C:\` quando usado por Docker e ferramentas Linux.
+
+### Docker Dev Container
+
+O container de desenvolvimento aberto pelo VS Code. É o ambiente onde o Node 24, Git, dependências, scripts e o MCP server rodam.
+
+### MCP
+
+Model Context Protocol. É o protocolo que permite que aplicações de IA descubram e chamem tools, leiam resources e usem prompts expostos por um servidor externo.
+
+### MCP server
+
+O processo que publicará as capacidades do projeto. Ele deve ser escrito de modo a acessar o repo real e executar operações controladas.
+
+### Tool
+
+Uma função publicada pelo MCP server. Exemplos: ler arquivo, buscar no repo, retornar `git diff`, rodar teste, aplicar patch, criar branch.
+
+### Transport
+
+O meio pelo qual o cliente MCP e o servidor MCP trocam mensagens. Neste projeto, os transportes relevantes são `stdio` e Streamable HTTP. SSE fica apenas como fallback legado.
+
+### Project Control Plane
+
+A camada local que organiza operações sobre o projeto: filesystem, Git, jobs, logs, auditoria, locks, permissões, memória operacional e integração com Copilot.
+
+---
+
+## 4. O que significa “conectar o ChatGPT ao VS Code”
+
+A expressão pode ser enganosa. O ChatGPT não “entra” no VS Code. O que fazemos é:
+
+1. Rodar um MCP server dentro do mesmo Dev Container do VS Code.
+2. Dar a esse servidor acesso ao repositório real.
+3. Expor o servidor ao ChatGPT por um endpoint `/mcp` seguro.
+4. Cadastrar esse endpoint no formulário de “Novo app” ou “Conector” do ChatGPT.
+5. Permitir que o ChatGPT chame as tools do MCP server durante a conversa.
+
+Portanto, a conexão real é:
+
+```text
+ChatGPT → MCP endpoint → MCP server → repo no Dev Container
+```
+
+O VS Code aparece porque é o ambiente humano de edição e porque o Dev Container aberto no VS Code é o lugar onde tudo deve rodar.
+
+---
+
+## 5. Topologia recomendada
+
+### Topologia lógica
+
+```text
+Humano
+  ↓
+ChatGPT em chatgpt.com
+  ↓
+Custom App / Connector MCP
+  ↓
+Secure MCP Tunnel ou HTTPS público
+  ↓
+MCP server Node 24
+  ↓
+Project Control Plane
+  ↓
+Repo real + Git + scripts + logs
+```
+
+### Topologia física
+
+```text
+Windows
+  ↓
+WSL2
+  ↓
+Docker Desktop com backend WSL2
+  ↓
+VS Code Dev Container
+  ↓
+Node 24 + MCP server + Copilot SDK + repo
+```
+
+### Regra fundamental
+
+O MCP server deve rodar onde o repo é real. Se o projeto está em `/workspaces/meu-repo` dentro do Dev Container, o MCP server deve rodar nesse mesmo container ou em um container com o mesmo mount, os mesmos caminhos e o mesmo contexto Git.
+
+---
+
+## 6. Papel do WSL2
+
+O WSL2 é a base Linux dentro do Windows. Para projetos com Docker e Dev Containers, o local do filesystem importa muito.
+
+A Microsoft recomenda que projetos usados com Dev Containers no Windows fiquem no filesystem do WSL2, por exemplo:
+
+```text
+/home/<usuario>/projects/<repo>
+```
+
+Evite manter o projeto em:
+
+```text
+C:\Users\<usuario>\projects\<repo>
+```
+
+Motivo: quando o Docker acessa arquivos no filesystem Windows a partir de um container Linux, há uma ponte cross-OS mais lenta. Com o repo no filesystem WSL2, o I/O fica mais próximo de Linux nativo.
+
+Fonte oficial: https://learn.microsoft.com/en-us/windows/dev-environment/docker/dev-containers
+
+---
+
+## 7. Papel do Docker Dev Container
+
+O Dev Container torna o ambiente reprodutível. Em vez de depender do Node, Git, scripts e ferramentas instaladas no Windows, o projeto define seu ambiente em container.
+
+O Dev Container deve conter:
+
+- Node 24.
+- Git.
+- Ferramentas de build/test/lint do projeto.
+- Dependências necessárias ao MCP server.
+- Dependências necessárias ao GitHub Copilot SDK 0.3.0, quando aplicável.
+- Acesso ao repo em `/workspaces/<repo>`.
+- Local persistente para `.ai/`, logs, histórico de jobs e estado operacional.
+
+O VS Code permite configurar MCP servers dentro de Dev Containers por meio da seção `customizations.vscode.mcp` no `devcontainer.json`.
+
+Fonte oficial: https://code.visualstudio.com/docs/copilot/customization/mcp-servers
+
+---
+
+## 8. Papel do Node 24
+
+Node 24 é o runtime principal do nosso MCP server e do Project Control Plane.
+
+Ele é apropriado porque permite:
+
+- Servidor HTTP para Streamable HTTP `/mcp`.
+- CLI local para ferramentas auxiliares.
+- Integração com Git, shells e processos do projeto.
+- Uso de ESM moderno.
+- Controle de subprocessos e jobs.
+- Integração com o GitHub Copilot SDK 0.3.0.
+
+A recomendação arquitetural é usar Node 24 com ESM puro, separando:
+
+```text
+core do projeto
+  tools determinísticas
+  git/filesystem/jobs
+  auditoria/memória
+
+adaptadores MCP
+  stdio local
+  Streamable HTTP /mcp remoto
+
+integrações
+  Copilot SDK
+  terminal broker
+  repo-ai CLI
+```
+
+O Node Permission Model pode ser usado como mitigação operacional, mas não deve ser tratado como sandbox absoluto. Para liberdade ampla com segurança, a camada mais importante é o próprio desenho do MCP server: paths restritos ao workspace, logs, grants, locks e auditoria.
+
+Fonte oficial: https://nodejs.org/docs/latest-v24.x/api/permissions.html
+
+---
+
+## 9. Papel do MCP server
+
+O MCP server é a peça que transforma o repositório em uma superfície controlável por LLMs.
+
+Ele deve:
+
+- Declarar tools de forma clara.
+- Validar argumentos.
+- Executar operações no repo real.
+- Retornar resultados estruturados.
+- Controlar permissões.
+- Registrar auditoria.
+- Impedir fuga acidental para fora do workspace.
+- Ser rápido para leituras comuns.
+- Ser previsível para escrita e execução.
+
+A documentação da OpenAI descreve que o MCP server define tools, aplica autenticação e retorna dados; o modelo decide quando chamar as tools com base na descrição e metadados.
+Fonte oficial: https://developers.openai.com/apps-sdk/build/mcp-server
+
+---
+
+## 10. Transportes: stdio, Streamable HTTP e SSE
+
+### `stdio`
+
+`stdio` é o transporte local. O cliente inicia o processo do MCP server e fala com ele por stdin/stdout.
+
+Use para:
+
+- VS Code local.
+- Copilot SDK local.
+- Testes dentro do Dev Container.
+- Ferramentas que rodam no mesmo namespace do projeto.
+
+Não use como conexão direta do ChatGPT remoto, porque o ChatGPT não consegue iniciar um processo dentro do seu WSL2/Dev Container.
+
+### Streamable HTTP
+
+Streamable HTTP é o transporte remoto moderno do MCP. O servidor expõe um endpoint único, normalmente:
+
+```text
+/mcp
+```
+
+A especificação MCP define que esse transporte usa HTTP `POST` e `GET`, e pode usar SSE internamente para streaming. O servidor deve oferecer um único endpoint MCP que suporte esses métodos.
+
+Use para:
+
+- ChatGPT em `chatgpt.com`.
+- Secure MCP Tunnel.
+- API Playground.
+- Outras LLMs remotas.
+- Clientes que precisam de conexão de rede.
+
+Fonte oficial: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports
+
+### SSE legado
+
+SSE legado é o transporte antigo HTTP+SSE. Ele costuma envolver endpoints separados, como `/sse` e `/messages`.
+
+Use apenas se um cliente antigo exigir. Não deve ser a fundação nova do projeto.
+
+### Regra simples
+
+```text
+Dentro do Dev Container: stdio.
+Fora do Dev Container, incluindo ChatGPT: Streamable HTTP /mcp.
+SSE legado: apenas fallback.
+```
+
+---
+
+## 11. Por que o ChatGPT precisa de `/mcp` via HTTPS ou túnel
+
+O ChatGPT em `chatgpt.com` roda fora da sua máquina. Ele não conhece o `localhost` do seu Windows, nem o `localhost` do WSL2, nem o `localhost` do container.
+
+Por isso, quando você preenche o formulário de conector no ChatGPT, o campo “URL do servidor MCP” precisa apontar para uma URL que o ChatGPT consiga alcançar.
+
+A documentação oficial de conexão do ChatGPT diz para fornecer a URL pública do endpoint `/mcp`, como no padrão:
+
+```text
+https://<host-publico-ou-tunel>/mcp
+```
+
+Fonte oficial: https://developers.openai.com/apps-sdk/deploy/connect-chatgpt
+
+No nosso caso, como o MCP server é privado e local, a opção mais alinhada é usar Secure MCP Tunnel.
+
+---
+
+## 12. Secure MCP Tunnel
+
+O Secure MCP Tunnel permite conectar servidores MCP privados a produtos OpenAI sem expor o servidor diretamente à internet.
+
+A lógica é:
+
+```text
+ChatGPT
+  ↓
+endpoint OpenAI do túnel
+  ↓
+tunnel-client rodando no nosso ambiente
+  ↓
+MCP server local em 127.0.0.1:<porta>/mcp
+```
+
+O `tunnel-client` deve rodar dentro da rede que já alcança o MCP server. Em nosso caso, isso significa:
+
+- preferencialmente dentro do Dev Container; ou
+- em um container companheiro na mesma rede Docker; ou
+- no WSL2 host, se ele conseguir alcançar o endpoint interno do MCP server.
+
+O MCP server não precisa ter listener público. Ele pode escutar apenas em localhost, e o túnel faz a ponte outbound para a OpenAI.
+
+Fonte oficial: https://developers.openai.com/api/docs/guides/secure-mcp-tunnels
+
+---
+
+## 13. O formulário do ChatGPT mostrado na imagem
+
+A imagem mostra a criação de um “Novo app” ou conector MCP em `chatgpt.com`.
+
+### Ícone
+
+Opcional. Não afeta a conexão.
+
+### Nome
+
+Use um nome humano e específico. Exemplo:
+
+```text
+Repo DevContainer MCP
+```
+
+ou:
+
+```text
+MCP Server para Repo VS Code
+```
+
+### Descrição
+
+A descrição é importante porque ajuda o modelo a entender quando usar o conector. Ela deve dizer o que o servidor faz e em que contexto deve ser usado.
+
+Exemplo conceitual:
+
+```text
+Conecta ao repositório aberto no VS Code dentro do WSL2 Docker Dev Container. Permite ler arquivos, buscar no código, inspecionar Git, rodar diagnósticos, executar jobs controlados e coordenar integrações locais do projeto.
+```
+
+### URL do servidor MCP
+
+Este é o campo crítico.
+
+Não use:
+
+```text
+http://localhost:3333/mcp
+```
+
+Use uma URL acessível pelo ChatGPT:
+
+```text
+https://<endpoint-do-tunel-ou-host>/mcp
+```
+
+Se for Secure MCP Tunnel, use o endpoint fornecido pela configuração do túnel OpenAI.
+
+### Autenticação
+
+Para desenvolvimento, pode haver modo sem autenticação dependendo do cenário e da configuração disponível. Para uso real, prefira OAuth ou uma combinação com túnel, grants locais e auditoria.
+
+A documentação de autenticação da OpenAI observa que o ChatGPT não apresenta API keys customizadas nem grants machine-to-machine como client credentials; para identificação de cliente, há suporte a mecanismos como mTLS gerenciado pela OpenAI em servidores MCP que validam certificados de cliente.
+
+Fonte oficial: https://developers.openai.com/apps-sdk/build/auth
+
+### Aviso de risco
+
+O aviso existe porque um MCP server pode executar ações reais. No nosso caso, isso é intencional: queremos controle amplo do repo. A resposta correta não é desativar poder; é desenhar poder com auditoria, grants, locks e reversibilidade via Git.
+
+---
+
+## 14. Autenticação e confiança
+
+A conexão tem três camadas de confiança:
+
+### Camada 1 — Transporte
+
+O endpoint deve ser HTTPS quando acessado pelo ChatGPT. Com Secure MCP Tunnel, a conexão externa fica mediada pela infraestrutura da OpenAI e o tráfego do ambiente local sai por conexão outbound.
+
+### Camada 2 — Identidade do cliente
+
+Em produção, use OAuth, mTLS validado, allowlist ou controles equivalentes conforme o tipo de publicação. Evite depender de segredo fixo em header se o cliente não puder apresentá-lo oficialmente.
+
+### Camada 3 — Permissões internas do projeto
+
+Mesmo que o ChatGPT consiga chamar o MCP, o servidor deve decidir o que cada tool pode fazer.
+
+Perfis recomendados:
+
+```text
+observe — leitura, busca, status, logs.
+edit — escrita controlada, patches e arquivos no workspace.
+build — execução de testes, lint, build e diagnósticos.
+ops — instalação, scripts mais amplos, processos e tarefas.
+admin — comandos livres temporários com grant explícito e auditoria.
+```
+
+---
+
+## 15. Como o MCP server deve enxergar o repositório
+
+O MCP server deve ter um `REPO_ROOT` explícito, por exemplo:
+
+```text
+/workspaces/<repo>
+```
+
+Todas as operações de arquivo devem resolver caminhos relativos a esse root. O servidor deve recusar:
+
+- paths absolutos fora do workspace;
+- `..` que escapem do root;
+- leitura acidental de `.ssh`, tokens e secrets;
+- escrita fora do repo;
+- uso não auditado do Docker socket.
+
+O objetivo é ter liberdade ampla dentro do projeto, não liberdade acidental sobre a máquina inteira.
+
+---
+
+## 16. Tools essenciais do MCP server
+
+O primeiro MCP server deve expor poucas tools, mas sólidas.
+
+### Tools de descoberta
+
+```text
+repo_status
+repo_tree
+repo_find
+repo_read_file
+repo_search_text
+```
+
+Essas tools permitem que o ChatGPT entenda o projeto sem alterar nada.
+
+### Tools de Git
+
+```text
+git_status
+git_diff
+git_log
+git_show
+git_branch_info
+```
+
+Essas tools tornam o estado verificável.
+
+### Tools de diagnóstico
+
+```text
+project_doctor
+list_scripts
+read_package_metadata
+```
+
+Essas tools ajudam o modelo a entender como trabalhar no projeto.
+
+---
+
+## 17. Tools intermediárias
+
+Depois da leitura segura, entram escrita e execução controlada.
+
+### Escrita
+
+```text
+write_file
+apply_patch
+create_file
+move_file
+remove_file
+```
+
+Toda escrita deve gerar auditoria e preferencialmente passar por patch/diff.
+
+### Execução
+
+```text
+run_script
+run_test
+run_lint
+run_build
+spawn_job
+get_job_output
+cancel_job
+```
+
+Operações longas devem virar jobs assíncronos, não chamadas bloqueantes sem rastreio.
+
+### Contexto
+
+```text
+context_pack_create
+context_pack_read
+event_log_append
+memory_note_write
+```
+
+Essas tools permitem continuidade entre ChatGPT, terminal, VS Code e outras LLMs.
+
+---
+
+## 18. Tools avançadas
+
+Com a base estável, o MCP server pode expor capacidades mais fortes.
+
+```text
+create_worktree
+switch_task_branch
+run_admin_command
+copilot_session_create
+copilot_send_and_wait
+copilot_steer
+copilot_get_events
+```
+
+`run_admin_command` não deve ser a primeira tool do sistema. Ela é útil, mas deve vir com token local temporário, auditoria e kill switch.
+
+---
+
+## 19. VS Code usando o mesmo MCP server
+
+O VS Code pode usar MCP servers diretamente. Para uso local no Dev Container, prefira `stdio`.
+
+Conceito:
+
+```text
+VS Code Chat/Copilot
+  ↓ stdio
+MCP server Node 24
+  ↓
+repo local
+```
+
+Para HTTP, o VS Code pode conectar a servidores MCP por `type: "http"`; a documentação informa que ele tenta HTTP Stream e faz fallback para SSE quando necessário. Também há suporte a HTTP via Unix socket ou named pipe em cenários específicos.
+
+Fonte oficial: https://code.visualstudio.com/docs/copilot/reference/mcp-configuration
+
+---
+
+## 20. GitHub Copilot SDK 0.3.0 no desenho
+
+O GitHub Copilot SDK 0.3.0 é independente do ChatGPT, mas pode ser integrado ao mesmo ambiente.
+
+Ele pode atuar de duas maneiras:
+
+1. Como consumidor do nosso MCP server local.
+2. Como runtime local de agente por meio de Copilot CLI headless.
+
+A documentação do GitHub diz que o Copilot SDK pode integrar MCP servers que rodam como processos separados e expõem tools. Ela também distingue servidores locais/stdio e HTTP/SSE.
+
+Fonte oficial: https://docs.github.com/en/copilot/how-tos/copilot-sdk/use-copilot-sdk/mcp-servers
+
+As release notes do SDK 0.3.0 indicam mudanças importantes: a terminologia de configuração MCP foi alinhada para `stdio` e `http`, e o vocabulário de permissões foi refinado para resultados como `approve-once`, `approve-for-session` e `approve-for-location`.
+
+Fonte oficial: https://github.com/github/copilot-sdk/releases
+
+---
+
+## 21. Copilot CLI headless + `cliUrl`
+
+O modo mais robusto para integrar Copilot local é rodar o Copilot CLI em modo headless dentro do Dev Container ou em container companheiro.
+
+A ideia:
+
+```text
+Copilot CLI headless
+  ↑ TCP / cliUrl
+Copilot SDK Node 24
+  ↑ MCP tool
+ChatGPT ou outro orquestrador
+```
+
+Segundo a documentação do GitHub, nesse modo a CLI roda como servidor persistente; o backend se conecta por TCP usando `cliUrl`; múltiplos clientes SDK podem compartilhar o mesmo servidor.
+
+Fonte oficial: https://docs.github.com/en/copilot/how-tos/copilot-sdk/set-up-copilot-sdk/backend-services
+
+Isso não substitui o MCP server. Ele complementa:
+
+```text
+ChatGPT
+  ↓
+MCP server
+  ↓
+Copilot Bridge
+  ↓
+Copilot SDK
+  ↓
+Copilot CLI headless
+  ↓
+repo
+```
+
+O ChatGPT continua chamando tools MCP. O Copilot local pode ser acionado como executor especializado.
+
+---
+
+## 22. Como outras LLMs entram no sistema
+
+Outras LLMs ou agentes podem usar o mesmo projeto se suportarem MCP ou se forem conectadas por uma ponte própria.
+
+Modelos de conexão:
+
+```text
+LLM local → stdio → MCP server
+LLM remota → HTTPS /mcp → MCP server
+LLM remota → túnel → MCP server
+Copilot SDK → stdio/http → MCP server
+```
+
+A vantagem do MCP é evitar criar uma integração diferente para cada LLM. O repositório expõe um contrato comum; cada cliente usa o transporte compatível.
+
+---
+
+## 23. Memória operacional compartilhada
+
+A conversa do ChatGPT pode ser efêmera. O projeto não deve ser.
+
+Crie uma pasta de estado operacional:
+
+```text
+.ai/
+  context-pack.md
+  tasks/
+  logs/
+  jobs/
+  audit/
+  decisions/
+```
+
+Essa pasta serve para:
+
+- registrar decisões;
+- guardar estado de tarefas;
+- permitir retomada por outra LLM;
+- tornar operações auditáveis;
+- reduzir dependência da memória da conversa;
+- permitir que terminal, ChatGPT, VS Code e Copilot compartilhem contexto.
+
+Para humanos e LLMs, o arquivo mais importante é o `context-pack.md`, que deve explicar o estado atual do projeto, próximos passos, comandos recentes, diffs relevantes e decisões tomadas.
+
+---
+
+## 24. Segurança sem amputar liberdade
+
+O objetivo não é limitar o sistema a leitura. O objetivo é permitir controle amplo de maneira rastreável.
+
+Princípios:
+
+1. O repo é o limite operacional padrão.
+2. Escritas devem gerar diff.
+3. Comandos devem gerar job log.
+4. Operações destrutivas exigem grant explícito.
+5. Secrets devem ser protegidos por denylist e detecção.
+6. Docker socket não deve ser exposto por padrão.
+7. Ações devem ser reversíveis por Git quando possível.
+8. Tool descriptions devem ser claras para evitar uso incorreto pelo modelo.
+9. Prompt injection em arquivos do repo deve ser tratado como dado não confiável.
+10. Liberdade máxima deve ser temporária, auditada e revogável.
+
+---
+
+## 25. Fluxo de implementação recomendado
+
+### Fase 1 — Ambiente
+
+- Repo no filesystem WSL2.
+- VS Code aberto em WSL2.
+- Dev Container funcional.
+- Node 24 dentro do container.
+- Scripts básicos do projeto funcionando.
+
+### Fase 2 — MCP local de leitura
+
+- Criar MCP server Node 24.
+- Rodar via `stdio` dentro do Dev Container.
+- Expor tools de leitura e Git.
+- Testar no VS Code ou MCP Inspector.
+
+### Fase 3 — Project Control Plane
+
+- Criar camada de paths, auditoria e logs.
+- Criar `.ai/`.
+- Criar `project_doctor`.
+- Criar tools de diagnóstico.
+
+### Fase 4 — Streamable HTTP `/mcp`
+
+- Adicionar adaptador HTTP.
+- Bind local em `127.0.0.1` para desenvolvimento.
+- Validar `Origin` quando aplicável.
+- Preparar autenticação ou proteção por túnel.
+
+### Fase 5 — Secure MCP Tunnel
+
+- Rodar o `tunnel-client` onde ele alcança o MCP server.
+- Apontar o túnel para o endpoint local `/mcp`.
+- Usar a URL do túnel no formulário do ChatGPT.
+
+### Fase 6 — ChatGPT
+
+- Criar o conector no ChatGPT.
+- Preencher nome, descrição, URL `/mcp` e autenticação.
+- Confirmar que as tools aparecem.
+- Testar leitura do repo.
+- Depois testar escrita controlada.
+
+### Fase 7 — Copilot SDK 0.3.0
+
+- Integrar Copilot SDK como consumidor local.
+- Opcionalmente iniciar Copilot CLI headless.
+- Conectar via `cliUrl`.
+- Expor tools MCP de delegação ao Copilot local.
+
+### Fase 8 — Operação avançada
+
+- Jobs assíncronos.
+- Worktrees.
+- Locks.
+- Event bus.
+- Grants temporários.
+- Admin command auditado.
+
+---
+
+## 26. Smoke tests
+
+Antes de conectar o ChatGPT, valide localmente:
+
+```text
+1. O MCP server sobe no Dev Container.
+2. Ele enxerga /workspaces/<repo>.
+3. repo_status retorna o branch correto.
+4. repo_read_file lê um arquivo conhecido.
+5. git_diff retorna o diff atual.
+6. project_doctor identifica Node 24, Git e scripts.
+7. O endpoint /mcp responde localmente.
+8. O túnel consegue alcançar /mcp.
+9. O ChatGPT lista as tools após criar o conector.
+10. Uma chamada simples de leitura funciona na conversa.
+```
+
+Depois:
+
+```text
+11. apply_patch cria um diff esperado.
+12. run_test cria job log.
+13. get_job_output retorna logs.
+14. cancel_job interrompe processo longo.
+15. audit log registra cada ação.
+```
+
+---
+
+## 27. Diagnóstico de falhas comuns
+
+### ChatGPT não conecta
+
+Prováveis causas:
+
+- URL não é HTTPS.
+- URL aponta para localhost.
+- `/mcp` não está exposto corretamente.
+- Tunnel client não está rodando.
+- MCP server caiu.
+- Autenticação não está compatível.
+
+### Tools não aparecem
+
+Prováveis causas:
+
+- O servidor não respondeu ao handshake MCP.
+- Tool schema inválido.
+- Descrição ou metadados quebrados.
+- Endpoint errado.
+- Servidor responde HTML/erro em vez de JSON-RPC/MCP.
+
+### VS Code funciona, ChatGPT não
+
+Provável causa:
+
+- VS Code está usando `stdio`, mas ChatGPT precisa de HTTP/túnel.
+
+### ChatGPT funciona, mas não vê arquivos certos
+
+Prováveis causas:
+
+- MCP server rodando fora do Dev Container.
+- `REPO_ROOT` aponta para caminho errado.
+- Repo está no Windows filesystem e não no WSL2.
+- Container companheiro não montou o mesmo workspace.
+
+### Performance ruim
+
+Prováveis causas:
+
+- Repo em `C:\`.
+- `node_modules` em bind mount lento.
+- Busca textual sem índice.
+- Tools retornando contexto excessivo.
+- Jobs longos sendo executados de modo síncrono.
+
+A documentação do VS Code recomenda volumes nomeados para diretórios de alta escrita, como `node_modules`, caches e build outputs, quando performance de bind mount é um problema.
+
+Fonte oficial: https://code.visualstudio.com/remote/advancedcontainers/improve-performance
+
+---
+
+## 28. Decisões canônicas
+
+1. O repo deve ficar no filesystem WSL2.
+2. O VS Code deve abrir o repo em Dev Container.
+3. O MCP server deve rodar no mesmo ambiente do repo.
+4. Node 24 é o runtime padrão.
+5. `stdio` é o transporte local principal.
+6. Streamable HTTP `/mcp` é o transporte remoto principal.
+7. SSE legado é apenas compatibilidade.
+8. ChatGPT não usa `localhost`; usa HTTPS ou Secure MCP Tunnel.
+9. O formulário do ChatGPT recebe a URL pública/tunelada `/mcp`.
+10. O MCP server deve começar por leitura e Git antes de escrita e execução.
+11. Escrita e execução devem ser auditadas.
+12. GitHub Copilot SDK 0.3.0 entra como camada local complementar.
+13. Copilot CLI headless + `cliUrl` é o attach robusto para backend local.
+14. `.ai/` é a memória operacional compartilhada.
+15. Liberdade ampla exige logs, grants, locks e reversibilidade.
+
+---
+
+## 29. Fontes oficiais
+
+### OpenAI / ChatGPT / MCP
+
+- Connect from ChatGPT — Apps SDK:
+  https://developers.openai.com/apps-sdk/deploy/connect-chatgpt
+
+- Build your MCP server — Apps SDK:
+  https://developers.openai.com/apps-sdk/build/mcp-server
+
+- Secure MCP Tunnel — OpenAI API:
+  https://developers.openai.com/api/docs/guides/secure-mcp-tunnels
+
+- MCP and Connectors — OpenAI API:
+  https://developers.openai.com/api/docs/guides/tools-connectors-mcp
+
+- Authentication — Apps SDK:
+  https://developers.openai.com/apps-sdk/build/auth
+
+### Model Context Protocol
+
+- MCP specification — transports:
+  https://modelcontextprotocol.io/specification/2025-03-26/basic/transports
+
+- MCP specification index:
+  https://modelcontextprotocol.io/specification
+
+### VS Code / Dev Containers / WSL2
+
+- Add and manage MCP servers in VS Code:
+  https://code.visualstudio.com/docs/copilot/customization/mcp-servers
+
+- MCP configuration reference — VS Code:
+  https://code.visualstudio.com/docs/copilot/reference/mcp-configuration
+
+- Developing inside a Container — VS Code:
+  https://code.visualstudio.com/docs/devcontainers/containers
+
+- Improve Dev Container performance — VS Code:
+  https://code.visualstudio.com/remote/advancedcontainers/improve-performance
+
+- Dev Containers on Windows with WSL2 — Microsoft Learn:
+  https://learn.microsoft.com/en-us/windows/dev-environment/docker/dev-containers
+
+### GitHub Copilot SDK / CLI
+
+- Copilot SDK backend services:
+  https://docs.github.com/en/copilot/how-tos/copilot-sdk/set-up-copilot-sdk/backend-services
+
+- Copilot SDK with MCP servers:
+  https://docs.github.com/en/copilot/how-tos/copilot-sdk/use-copilot-sdk/mcp-servers
+
+- Copilot SDK releases:
+  https://github.com/github/copilot-sdk/releases
+
+- About GitHub Copilot CLI:
+  https://docs.github.com/copilot/concepts/agents/about-copilot-cli
+
+### Node.js
+
+- Node.js documentation:
+  https://nodejs.org/docs/latest-v24.x/api/
+
+- Node.js Permission Model:
+  https://nodejs.org/docs/latest-v24.x/api/permissions.html
+
+---
+
+## 30. Conclusão
+
+A conexão correta entre ChatGPT e o nosso VS Code em WSL2 Docker Dev Container não é uma conexão visual com o editor, nem uma tentativa de controlar a tela do terminal. É uma conexão protocolar.
+
+O ChatGPT se conecta a um endpoint MCP. Esse endpoint chega a um MCP server Node 24 rodando dentro do Dev Container. Esse servidor opera o repositório real, com tools bem definidas, logs, grants, Git, jobs e memória compartilhada.
+
+O desenho final é simples na superfície e forte internamente:
+
+```text
+ChatGPT
+  ↓
+Connector MCP em /mcp
+  ↓
+Secure MCP Tunnel ou HTTPS
+  ↓
+MCP server Node 24 no Dev Container
+  ↓
+Project Control Plane
+  ↓
+Repo real do VS Code
+```
+
+Para o humano, isso significa poder pedir ao ChatGPT para investigar, editar, testar, revisar e coordenar o projeto. Para outras LLMs, significa uma interface padronizada. Para o sistema, significa que o projeto deixa de depender de uma conversa específica e passa a ter uma superfície operacional própria.
+
+A implementação deve começar pequena: leitura, Git e diagnóstico. Em seguida, escrita controlada. Depois, jobs. Por fim, Copilot SDK 0.3.0, Copilot CLI headless, worktrees, event bus e multiagente.
+
+O resultado esperado é um ambiente no qual o ChatGPT e outros agentes não apenas “comentam” sobre o projeto, mas conseguem operar o projeto dentro do mesmo ambiente real em que ele é desenvolvido.

--- a/DOCUMENTAÇÃO/AUDITORIAS/COPILOT-AUDIT-REPORTS/TERMINAL-SESSION-COMMANDS-SDK-CANONICAL-ROADMAP-CODEX-2026-05-22.md
+++ b/DOCUMENTAÇÃO/AUDITORIAS/COPILOT-AUDIT-REPORTS/TERMINAL-SESSION-COMMANDS-SDK-CANONICAL-ROADMAP-CODEX-2026-05-22.md
@@ -315,3 +315,28 @@ Quarta fatia concluida:
 - Evidencia live no-PR: `artifacts/terminal-live/2026-05-22T00-52-07-706Z/summary.md` (PASS; criterios
   `sdk-session-command-catalog-visible`, `sdk-session-events-cockpit-visible` e
   `sdk-session-waits-cockpit-visible` verdes).
+
+Quinta fatia concluida - Faixa F:
+
+- Investigacao SDK local 0.3.0 confirmou que `SessionFsConfig` e `createSessionFsHandler` existem, mas
+  `session.updateMetadata` continua ausente. A correcao, portanto, nao tenta escrever metadata no SDK; ela persiste
+  metadata local redigida no estado do agent.
+- `src/copilot/sdk/session/session-fs.js` agora expoe `describeConfiguredSessionFs()` e
+  `readConfiguredSessionFsState()`, reaproveitando a configuracao canonica de boot e retornando paths seguros
+  (`workspace:<relativo>` ou `external:<basename>`) com estado `exists/missing/unknown`.
+- `src/copilot/agent/session/initializers/initializer.js` persiste `sdkSessionLocalMetadata` por `sessionId`, contendo
+  modelo, reasoning, provider redigido e boundary/decisao de boot. O mapa e limitado para evitar crescimento indefinido.
+- `src/copilot/presentation/runtime/sdk-session.js` enriquece o inventario de sessoes com `sessionFs` e metadata local,
+  sem depender de API SDK inexistente e enriquecendo com I/O apenas a janela solicitada pelo terminal.
+- `/session sdk` agora mostra Session FS, metadata local provider/modelo/boundary, filtros `cwd`, `gitRoot`, `repo`/
+  `repository`, `branch`, e paginacao `offset=<n>`/`limit` numerico.
+- A exclusao continua protegendo a sessao SDK viva; os novos metadados sao somente diagnosticos/operacionais e nao
+  reabrem caminho paralelo de delete ou resume.
+- Testes focados: `node scripts/ci/run-vitest-copilot.mjs tests/unit/copilot/sdk/test_sdk_session_fs.spec.js
+  tests/unit/copilot/terminal/test_commands_session.spec.js`.
+- Validadores executados nesta fatia: `npm run typecheck:strict:src.copilot` PASS; `npm run lint:copilot` PASS;
+  testes focados PASS.
+- `npm run test:copilot` completo foi executado e falhou em achados globais ja fora da Faixa F imediata. Uma violacao
+  introduzida durante a fatia (`presentation/runtime/sdk-session.js` importando `#copilot/sdk/session`) foi corrigida,
+  movendo o acesso a SessionFs para a facade do agent. O rerun focado de soberania deixou apenas o achado preexistente
+  de `hooks/session-hooks.js`.

--- a/relatorio-auditoria-tools-read.md
+++ b/relatorio-auditoria-tools-read.md
@@ -1,0 +1,270 @@
+# Auditoria Profunda — Tools de Read
+
+**Gerado em**: 2026-05-21T21:40Z
+**Escopo**: src/copilot/tools/file/read/ + shared.js + read-tools.js + index-tools.js + scope-tools.js + io-cache.js + read-text.js + safe_read.js
+**Status**: Canônico ativo — análise somente, nenhuma alteração aplicada
+
+---
+
+## 1. Situação Atual
+
+### Estrutura canônica
+
+```
+src/copilot/tools/file/
+├── index.js                  # barrel público (barrel-only ✓)
+├── shared.js                 # validatePath + constants + buffer utils
+├── read-tools.js             # superfície pública: readFileContentTool + listDirectoryTool + diffFilesTool
+├── read/
+│   ├── index.js              # barrel interno (barrel-only ✓)
+│   ├── read-file-content.js  # handler completo 419 linhas
+│   ├── window.js             # parseReadCursor + nextLineCursor
+│   ├── metadata.js           # buildReadFileMetadata
+│   └── feedback.js           # createReadFileFailure
+├── index-tools.js            # workspace_index_* + workspace_parse_file
+├── scope-tools.js            # workspace_scope_* (6 tools)
+└── README.md
+```
+
+### IO associada
+
+```
+src/copilot/infra/
+├── io-cache.js               # L1 cache (LRU, 128 MiB, 60s TTL, fingerprint)
+├── io/fs/read-text.js        # readText / readTextChunks (42 linhas)
+├── io/fs/read-bytes.js       # readBytes (25 linhas)
+├── shared/buffer.js          # truncate/concat/decode
+├── shared/fingerprint-match.js
+├── shared/hash.js
+├── io/invalidation/bus.js    # event bus invalidation
+└── cache/l1/index.js         # makeBytesKey/makeTextKey
+
+src/infra/fs/safe_read.js     # LEGACY — safeReadJSON com retry + quarentena
+```
+
+### Status por arquivo
+
+| Arquivo | Linhas | Status |
+|---|---|---|
+| read/index.js | 13 | ✅ barrel-only puro |
+| read/read-file-content.js | 419 | ⚠️ handler complexo (5 responsabilidades) |
+| read/window.js | 58 | ✅ bem separado |
+| read/metadata.js | 73 | ✅ builder canônico |
+| read/feedback.js | 71 | ✅ estruturado |
+| read-tools.js | 206 | ⚠️ truncado runtime, topo 4 linhas não lidas |
+| shared.js | 296 | ⚠️ truncado runtime |
+| index-tools.js | 357 | ⚠️ truncado runtime |
+| scope-tools.js | 214 | ✅ bom |
+| io-cache.js | 358 | ⚠️ arquivo grande para componente isolado |
+| read-text.js | 42 | ✅ perfeito |
+| read-bytes.js | 25 | ✅ perfeito |
+| safe_read.js (legacy) | 83 | ⚠️ quarentena ativa, console.error direto |
+
+---
+
+## 2. Bugs Encontrados
+
+### BUG-1 — nextCursor ausente no modo stream
+**Severidade**: Média
+**Arquivo**: read/read-file-content.js
+**Evidência**: nextLineCursor só é chamado no branch cached. No branch stream o cursor não é calculado nem adicionado ao retorno.
+**Impacto**: Paginação interrompida em readStrategy=stream.
+**Fix**: calcular nextCursor logo após bloco returnedLines no branch stream; adicionar ao retorno JSON.
+
+### BUG-2 — parseReadCursor retorna ok=true, value=null para cursor ausente
+**Severidade**: Baixa
+**Arquivo**: read/window.js
+**Evidência**: undefined/null/'' retornam { ok: true, value: null }. Semântica ambígua: é um valor válido nulo ou ausência de cursor?
+**Impacto**: dificulta leitura; caller precisa testar ok && value !== null como condição composta.
+**Sugestão**: { ok: false, reason: 'cursor ausente' } OU documentar explicitamente.
+
+---
+
+## 3. Gaps e Oportunidades
+
+### GAP-1 — io-cache.js 358 linhas em arquivo único
+**Severidade**: Alta (manutenibilidade)
+**Proposta**: decompor em io-cache-config.js, io-cache-instance.js, io-cache-ops.js, io-cache-stats.js, io-cache-hooks.js.
+
+### GAP-2 — safe_read.js é legacy sem integração canônica
+**Severidade**: Média
+**Proposta**: grep "safe_read" em src/ tests/ scripts/; se zero importadores em produção arquivar em infra/fs/legacy/ com @deprecated.
+
+### GAP-3 — read-file-content.js handler mistura 5 responsabilidades (419 linhas)
+**Severidade**: Média
+**Proposta**: extrair params.js + handler-text/stream/binary.js + next-cursor.js.
+
+### GAP-4 — Falta documento de contrato de cursor
+**Severidade**: Baixa
+**Proposta**: criar docs/cursor-contract.md com formato por ferramenta.
+
+### GAP-5 — validatePath acoplada ao boot via WORKSPACE_ROOT
+**Severidade**: Baixa (acoplamento intencional)
+**Proposta**: documentar no JSDoc; adicionar workspaceRoot opcional para testes.
+
+### GAP-6 — io-cache pub-sub sem subscriber default
+**Severidade**: Baixa
+**Proposta**: registrar subscriber L2 no boot de io-cache; adicionar teste E2E de invalidation.
+
+### GAP-7 — streamHighWaterMark constraint excessiva (até 16 MiB)
+**Severidade**: Baixa
+**Proposta**: limitar max a 1 MiB; documentar fallback para cache completo.
+
+### GAP-8 —缺少 Zod schema de retorno canônico
+**Severidade**: Baixa
+**Proposta**: adicionar ReadFileContentResponseSchema em shared.js.
+
+---
+
+## 4. Proposta de Situação Ideal
+
+### Estrutura alvo
+
+```
+src/copilot/tools/file/
+├── index.js                 # barrel-only inalterado
+├── shared.js                # validatePath + constants + Zod retornos
+├── read-tools.js            # superfície canônica única
+└── read/
+    ├── index.js             # barrel-only
+    ├── params.js            # validação Zod entrada
+    ├── window.js            # inalterado
+    ├── metadata.js          # inalterado
+    ├── feedback.js          # inalterado
+    ├── handler-text.js      # utf8 cached branch
+    ├── handler-stream.js    # utf8 stream branch
+    ├── handler-binary.js    # base64 branch
+    └── next-cursor.js       # cursor L1 isolado
+```
+
+### Objetivos
+
+| Objetivo | Critério |
+|---|---|
+| Handler ≤ 80 linhas | Cada handler especializado |
+| Zero duplicação | Todos usam readText/readBytes/readTextChunks |
+| Cursor canônico | parseReadCursor tipo documentado |
+| Schema de retorno | ReadFileContentResponseSchema em shared.js |
+| safe_read arquivado | zero importadores em src/copilot/ |
+| io-cache ≤ 100 linhas/file | 4 arquivos no lugar de 1 |
+| Testes isolados | Cada handler com teste próprio |
+
+---
+
+## 5. Roadmap
+
+### Faixa A — Correção de bugs
+
+#### Fase A1 — Cursores no modo stream
+- A1.1 Adicionar nextLineCursor no branch stream
+- A1.2 nextCursor no retorno JSON
+- A1.3 Teste unitário stream 300 linhas
+- A1.4 Smoke test canônico
+
+#### Fase A2 — Clarificar parseReadCursor
+- A2.1 Decidir semântica (manter ou mudar)
+- A2.2 Documentar ou migrar callers
+
+**Fecho Faixa A**: test:unit verde, lint verde, BUG-1 e BUG-2 fechados ou documentamente adiados.
+
+---
+
+### Faixa B — Decomposição de handlers
+
+#### Fase B1 — params.js
+- B1.1 Extrair validação/normalização
+- B1.2 Zod schemas exportados
+- B1.3 read-file-content.js importa params
+- B1.4 Testes confirmam códigos de erro inalterados
+
+#### Fase B2 — Handlers especializados
+- B2.1 handler-text.js (utf8 cached)
+- B2.2 handler-stream.js (utf8 stream)
+- B2.3 handler-binary.js (base64)
+- B2.4 read-file-content.js vira dispatcher puro ≤60 linhas
+
+#### Fase B3 — next-cursor.js
+- B3.1 Mover nextLineCursor + parseReadCursor
+- B3.2 Documentar contrato no JSDoc
+- B3.3 Atualizar read/index.js barrel
+
+#### Fase B4 — Schema de retorno canônico
+- B4.1 ReadFileContentResponseSchema em shared.js
+- B4.2 Usar em feedback + mocks de teste
+
+**Fecho Faixa B**: read-file-content.js ≤80 linhas; cada handler tem teste; lint+typecheck verdes.
+
+---
+
+### Faixa C — io-cache decomposição
+
+#### Fase C1 — Tipos e config
+- C1.1 io-cache-config.js (env + defaults)
+- C1.2 io-cache-types.js (typedefs export)
+
+#### Fase C2 — Instance e ops
+- C2.1 io-cache-instance.js (factory singleton)
+- C2.2 io-cache-ops.js (CRUD + getVerified + invalidate)
+
+#### Fase C3 — Stats e subscriber default
+- C3.1 io-cache-stats.js (stats + reset)
+- C3.2 io-cache-hooks.js (pub-sub + subscriber default L2)
+
+#### Fase C4 — Validação
+- C4.1 Atualizar todos importadores
+- C4.2 lint:copilot + test:unit
+
+**Fecho Faixa C**: io-cache.js deletado; 4 arquivos novos; todos importadores atualizados.
+
+---
+
+### Faixa D — safe_read.js arquivamento
+
+#### Fase D1 — Mapear importadores
+- D1.1 grep "safe_read" em src/ tests/ scripts/
+
+#### Fase D2 — Decisão
+- D2.1 Sem importadores produção → infra/fs/legacy/safe_read.js @deprecated
+- D2.2 Se em uso → integrar ao io-cache como fallback
+
+#### Fase D3 — Migrar logs
+- D3.1 console.error/warn → log() canônico
+
+---
+
+### Faixa E — Documentação
+
+#### Fase E1 — Cursor contract
+- E1.1 Criar docs/cursor-contract.md
+- E1.2 Referenciar em file/README.md
+
+#### Fase E2 — Update file/README.md
+- E2.1 Seção "Cursor Contract"
+- E2.2 Documentar decomposição params + handler-*
+- E2.3 Link para este relatório
+
+#### Fase E3 — Module map
+- E3.1 Atualizar module-map.js
+- E3.2 npm run audit:quick
+
+---
+
+## 6. Resumo de Priorização
+
+| Faixa | Prioridade | Esforço | Dependências |
+|---|---|---|---|
+| A1 cursors no stream | 🔴 Crítica | 1-2h | Nenhuma |
+| A2 parseReadCursor | 🟡 Média | 0.5h | Decisão |
+| B4 schema retorno | 🟡 Baixa | 1h | Independente |
+| B1 params.js | 🟡 Média | 2-3h | A1 fechado |
+| B2 handlers | 🟡 Média | 3-4h | B1 |
+| B3 cursor.js | 🟢 Baixa | 1h | B2 |
+| C1-C3 io-cache | 🟡 Média | 4-6h | Independente |
+| D safe_read | 🟢 Baixa | 1-2h | D1 primeiro |
+| E docs | 🟢 Baixa | 2-3h | Após B e C |
+
+**Ordem sugerida**: A1 → A2/B4 → B1 → B2 → B3 → C1 → E1 → E2 → C2-C3 → D → E3
+
+---
+
+*Análise somente — nenhuma alteração aplicada.*

--- a/src/copilot/agent/facades/index.js
+++ b/src/copilot/agent/facades/index.js
@@ -187,6 +187,7 @@ export {
     pingAgentSdkClient,
     pingSdk,
     raceAgentSdkEvents,
+    readAgentConfiguredSessionFsState,
     readAgentSdkModelRegistryEntry,
     readSdkSkillsGovernance,
     readSdkWorkspaceFile,

--- a/src/copilot/agent/facades/sdk-access.js
+++ b/src/copilot/agent/facades/sdk-access.js
@@ -83,6 +83,7 @@ export {
     listAgentSdkProtectedSessionIdsByClient,
     listAgentSdkSessionsByClient,
     listSdkSessions,
+    readAgentConfiguredSessionFsState,
     resumeOrCreateAgentSdkSession,
     setForegroundSdkSessionId,
 } from './sdk/index.js';

--- a/src/copilot/agent/facades/sdk/sessions.js
+++ b/src/copilot/agent/facades/sdk/sessions.js
@@ -12,6 +12,7 @@ import {
     createSession,
     deleteSession,
     getConfiguredSessionFsHandler,
+    readConfiguredSessionFsState,
     listSessions,
     resumeOrCreate,
 } from '#copilot/sdk/session';
@@ -88,6 +89,14 @@ export async function createAgentSdkSessionByClient(client, options) {
  */
 export function getAgentConfiguredSessionFsHandler() {
     return getConfiguredSessionFsHandler();
+}
+
+/**
+ * @param {string | null | undefined} [sessionId]
+ * @returns {ReturnType<typeof readConfiguredSessionFsState>}
+ */
+export function readAgentConfiguredSessionFsState(sessionId) {
+    return readConfiguredSessionFsState(sessionId);
 }
 
 /**

--- a/src/copilot/agent/lifecycle/state/state-io.js
+++ b/src/copilot/agent/lifecycle/state/state-io.js
@@ -90,6 +90,9 @@ import {
  * } | null} [sdkSessionBootDecision]
  *   Decisão redigida do initializer para a sessão SDK atual. Explica por que houve resume ou criação sem guardar
  *   credenciais/provider headers.
+ * @property {Record<string, Record<string, unknown>>} [sdkSessionLocalMetadata]
+ *   Metadata local, redigida e por sessionId, para enriquecer o cockpit sem depender de APIs inexistentes como
+ *   `session.updateMetadata`.
  * @property {{ mode: 'new'; requestedAt?: number } | { mode: 'resume'; sessionId: string; requestedAt?: number } | null} [nextSdkSessionBoot]
  *   Diretiva efêmera do operador para o próximo boot da sessão SDK; consumida pelo initializer.
  */

--- a/src/copilot/agent/session/initializers/initializer.js
+++ b/src/copilot/agent/session/initializers/initializer.js
@@ -401,6 +401,67 @@ function buildSdkSessionBootDecision(requestedMode, resumeCandidateSessionId, re
 }
 
 /**
+ * @param {unknown} value
+ * @returns {Record<string, Record<string, unknown>>}
+ */
+function readSdkSessionLocalMetadataMap(value) {
+    if (!value || typeof value !== 'object') return {};
+    /** @type {Record<string, Record<string, unknown>>} */
+    const out = {};
+    for (const [sessionId, metadata] of Object.entries(/** @type {Record<string, unknown>} */ (value))) {
+        if (!/^[a-zA-Z0-9_-]{8,128}$/u.test(sessionId)) continue;
+        if (!metadata || typeof metadata !== 'object') continue;
+        out[sessionId] = { .../** @type {Record<string, unknown>} */ (metadata) };
+    }
+    return out;
+}
+
+/**
+ * @param {import('../../lifecycle/state/index.js').AliveAgentState | null} state
+ * @param {string} sessionId
+ * @param {{
+ *     model: string;
+ *     reasoningEffort: 'low' | 'medium' | 'high' | 'xhigh' | undefined;
+ *     byokSessionBinding: ByokSessionBinding | null;
+ *     bootDecision: ReturnType<typeof buildSdkSessionBootDecision>;
+ * }} input
+ * @returns {Record<string, Record<string, unknown>>}
+ */
+function buildSdkSessionLocalMetadataMap(state, sessionId, input) {
+    const map = readSdkSessionLocalMetadataMap(state ? Reflect.get(state, 'sdkSessionLocalMetadata') : null);
+    map[sessionId] = {
+        sessionId,
+        updatedAt: Date.now(),
+        model: input.model,
+        reasoningEffort: input.reasoningEffort ?? null,
+        provider: input.byokSessionBinding
+            ? {
+                  kind: 'byok',
+                  profile: input.byokSessionBinding.profile,
+                  preset: input.byokSessionBinding.preset,
+                  providerType: input.byokSessionBinding.providerType,
+                  model: input.byokSessionBinding.model,
+              }
+            : {
+                  kind: 'github-copilot',
+                  model: input.model,
+              },
+        boundary: {
+            outcome: input.bootDecision.outcome,
+            requestedMode: input.bootDecision.requestedMode,
+            reason: input.bootDecision.reason,
+            resumeCandidateSessionId: input.bootDecision.resumeCandidateSessionId,
+            decidedAt: input.bootDecision.decidedAt,
+        },
+    };
+    return Object.fromEntries(
+        Object.entries(map)
+            .sort(([, a], [, b]) => Number(b['updatedAt'] ?? 0) - Number(a['updatedAt'] ?? 0))
+            .slice(0, 50),
+    );
+}
+
+/**
  * Inicializa ou retoma uma sessão Copilot SDK de forma persistente.
  *
  * Fluxo:
@@ -580,6 +641,7 @@ export async function initOrResumeSession(client, sessionOptions) {
         sdkSessionBootReason,
         result,
     );
+    const byokSessionBinding = buildByokSessionBinding(byok, model);
     if (byok.enabled && byok.provider) {
         Reflect.set(result.session, '__copilotByokEnabled', true);
         Reflect.set(result.session, '__copilotByokProvider', byok.provider);
@@ -619,6 +681,12 @@ export async function initOrResumeSession(client, sessionOptions) {
         byok.enabled && byok.supportsReasoning === false
             ? undefined
             : (result.reasoningEffort ?? sdkReasoningEffort ?? persistedReasoningEffort);
+    const sdkSessionLocalMetadata = buildSdkSessionLocalMetadataMap(state, result.session.sessionId, {
+        model: effectiveModel,
+        reasoningEffort: effectiveReasoningEffort,
+        byokSessionBinding,
+        bootDecision: sdkSessionBootDecision,
+    });
 
     // SYNC-SM-01 (fix): usar writeStateAsync nas chamadas dentro de funções async para não bloquear o event loop
     if (result.isResumed) {
@@ -629,8 +697,9 @@ export async function initOrResumeSession(client, sessionOptions) {
                 model: effectiveModel,
                 systemPromptBinding: buildSystemPromptBindingSnapshot(systemPromptStatus, result.session.sessionId),
                 reasoningEffort: effectiveReasoningEffort,
-                byokSessionBinding: buildByokSessionBinding(byok, model),
+                byokSessionBinding,
                 sdkSessionBootDecision,
+                sdkSessionLocalMetadata,
                 dialogPaused: false,
                 pendingTurnMessage: null,
                 pendingTurnTs: null,
@@ -654,8 +723,9 @@ export async function initOrResumeSession(client, sessionOptions) {
                 model: effectiveModel,
                 systemPromptBinding: buildSystemPromptBindingSnapshot(systemPromptStatus, result.session.sessionId),
                 reasoningEffort: effectiveReasoningEffort,
-                byokSessionBinding: buildByokSessionBinding(byok, model),
+                byokSessionBinding,
                 sdkSessionBootDecision,
+                sdkSessionLocalMetadata,
                 pendingQuestion: null,
                 pendingQuestionMeta: null,
                 nextSdkSessionBoot: null,

--- a/src/copilot/presentation/runtime/sdk-session.js
+++ b/src/copilot/presentation/runtime/sdk-session.js
@@ -20,6 +20,7 @@
 import {
     deleteAgentSdkPlan as deleteAgentSdkPlanOnAgent,
     persistAgentRuntimeStatePartial,
+    readAgentConfiguredSessionFsState,
     readAgentSdkPlan as readAgentSdkPlanFromAgent,
     readAgentSdkSessionMode,
     readAgentRuntimePersistedStateAsync,
@@ -84,6 +85,42 @@ export function resolveAgentSdkActiveSessionEntry(runtimeId, sessionId) {
         createdAt: Date.now(),
         messagesCount: 0,
     };
+}
+
+/**
+ * @param {unknown} value
+ * @returns {Record<string, Record<string, unknown>>}
+ */
+function readSdkSessionLocalMetadataMap(value) {
+    if (!value || typeof value !== 'object') return {};
+    /** @type {Record<string, Record<string, unknown>>} */
+    const out = {};
+    for (const [sessionId, metadata] of Object.entries(/** @type {Record<string, unknown>} */ (value))) {
+        if (typeof sessionId !== 'string' || !metadata || typeof metadata !== 'object') continue;
+        out[sessionId] = { .../** @type {Record<string, unknown>} */ (metadata) };
+    }
+    return out;
+}
+
+/**
+ * @param {Record<string, unknown> | null} state
+ * @param {string | null} currentSessionId
+ * @param {Record<string, unknown> | null} persistedByokBinding
+ * @param {Record<string, unknown> | null} lastBootDecision
+ * @returns {Record<string, Record<string, unknown>>}
+ */
+function buildRuntimeSdkSessionLocalMetadata(state, currentSessionId, persistedByokBinding, lastBootDecision) {
+    const map = readSdkSessionLocalMetadataMap(state ? Reflect.get(state, 'sdkSessionLocalMetadata') : null);
+    if (currentSessionId && !map[currentSessionId]) {
+        map[currentSessionId] = {
+            sessionId: currentSessionId,
+            updatedAt: Date.now(),
+            ...(typeof state?.['model'] === 'string' ? { model: state['model'] } : {}),
+            ...(persistedByokBinding ? { provider: { kind: 'byok', ...persistedByokBinding } } : {}),
+            ...(lastBootDecision ? { boundary: { ...lastBootDecision } } : {}),
+        };
+    }
+    return map;
 }
 
 /**
@@ -252,16 +289,21 @@ export async function setAgentSdkSessionMode(mode, runtimeId) {
  *
  * @param {string | null | undefined} [runtimeId]
  * @param {import('#copilot/sdk/types').SessionListFilter} [filter]
+ * @param {{ enrichOffset?: number; enrichLimit?: number }} [options]
  * @returns {Promise<{
  *     currentSessionId: string | null;
  *     lastSessionId: string | null;
  *     foregroundSessionId: string | null;
  *     persistedByokBinding: Record<string, unknown> | null;
  *     lastBootDecision: Record<string, unknown> | null;
- *     sessions: import('#copilot/sdk/types').SessionMetadata[];
+ *     sessionFs: Awaited<ReturnType<typeof readAgentConfiguredSessionFsState>>;
+ *     sessions: Array<import('#copilot/sdk/types').SessionMetadata & {
+ *         localMetadata?: Record<string, unknown> | null;
+ *         sessionFs?: Awaited<ReturnType<typeof readAgentConfiguredSessionFsState>>;
+ *     }>;
  * }>}
  */
-export async function listAgentSdkSessionInventory(runtimeId, filter) {
+export async function listAgentSdkSessionInventory(runtimeId, filter, options = {}) {
     const agent = getAgentSdkSessionTarget(runtimeId);
     const snap = readAgentStatusSnapshot(agent);
     const [lastSessionId, foregroundSessionId, sessions, state] = await Promise.all([
@@ -278,13 +320,45 @@ export async function listAgentSdkSessionInventory(runtimeId, filter) {
         state?.sdkSessionBootDecision && typeof state.sdkSessionBootDecision === 'object'
             ? /** @type {Record<string, unknown>} */ (state.sdkSessionBootDecision)
             : null;
+    const currentSessionId = typeof snap['sessionId'] === 'string' ? snap['sessionId'] : null;
+    const localMetadata = buildRuntimeSdkSessionLocalMetadata(
+        state && typeof state === 'object' ? /** @type {Record<string, unknown>} */ (state) : null,
+        currentSessionId,
+        persistedByokBinding,
+        lastBootDecision,
+    );
+    const sessionFs = await readAgentConfiguredSessionFsState(currentSessionId);
+    const enrichOffset =
+        typeof options.enrichOffset === 'number' && Number.isFinite(options.enrichOffset)
+            ? Math.max(0, Math.trunc(options.enrichOffset))
+            : 0;
+    const enrichLimit =
+        typeof options.enrichLimit === 'number' && Number.isFinite(options.enrichLimit)
+            ? Math.max(1, Math.min(100, Math.trunc(options.enrichLimit)))
+            : 25;
+    const enrichedSessions = await Promise.all(
+        sessions.map(async (session, index) => {
+            const base = {
+                ...session,
+                localMetadata: localMetadata[session.sessionId] ?? null,
+            };
+            if (session.sessionId !== currentSessionId && (index < enrichOffset || index >= enrichOffset + enrichLimit)) {
+                return base;
+            }
+            return {
+                ...base,
+                sessionFs: await readAgentConfiguredSessionFsState(session.sessionId),
+            };
+        }),
+    );
     return {
-        currentSessionId: typeof snap['sessionId'] === 'string' ? snap['sessionId'] : null,
+        currentSessionId,
         lastSessionId: typeof lastSessionId === 'string' ? lastSessionId : null,
         foregroundSessionId: typeof foregroundSessionId === 'string' ? foregroundSessionId : null,
         persistedByokBinding,
         lastBootDecision,
-        sessions,
+        sessionFs,
+        sessions: enrichedSessions,
     };
 }
 

--- a/src/copilot/sdk/index.js
+++ b/src/copilot/sdk/index.js
@@ -323,8 +323,10 @@ export {
     buildConfiguredClientSessionFsConfig,
     createLocalSessionFsProvider,
     createWorkspaceSessionFsHandler,
+    describeConfiguredSessionFs,
     getConfiguredSessionFsHandler,
     getConfiguredSessionIdleTimeoutSeconds,
+    readConfiguredSessionFsState,
 } from './session/session-fs.js';
 
 // ─── Faixa 7: RPC Core Subsystems (rev.4) ────────────────────────────────────

--- a/src/copilot/sdk/session/index.js
+++ b/src/copilot/sdk/session/index.js
@@ -176,8 +176,10 @@ export {
     buildConfiguredClientSessionFsConfig,
     createLocalSessionFsProvider,
     createWorkspaceSessionFsHandler,
+    describeConfiguredSessionFs,
     getConfiguredSessionFsHandler,
     getConfiguredSessionIdleTimeoutSeconds,
+    readConfiguredSessionFsState,
 } from './session-fs.js';
 
 export {

--- a/src/copilot/sdk/session/session-fs.js
+++ b/src/copilot/sdk/session/session-fs.js
@@ -21,7 +21,7 @@ import {
     scanDirectory,
     statPath,
 } from '#copilot/infra/public/io';
-import { dirname, resolve } from 'node:path';
+import { basename, dirname, isAbsolute, relative, resolve } from 'node:path';
 import { classifySdkError } from '../errors.js';
 import { log } from '../logger.js';
 import { emitSdkOperationMetric } from '../telemetry/operation-metrics.js';
@@ -160,6 +160,39 @@ function toSessionStorageKey(sessionId) {
         throw new TypeError('[sdk/session-fs] session.sessionId deve ser string não-vazia.');
     }
     return encodeURIComponent(sessionId.trim());
+}
+
+/**
+ * @param {string} absolutePath
+ * @param {string} workspaceRoot
+ * @returns {{ display: string; withinWorkspace: boolean }}
+ */
+function buildSafeSessionFsPathDisplay(absolutePath, workspaceRoot) {
+    const root = resolve(workspaceRoot);
+    const target = resolve(absolutePath);
+    const rel = relative(root, target).replace(/\\/gu, '/');
+    if (rel === '') {
+        return { display: 'workspace:.', withinWorkspace: true };
+    }
+    if (!rel.startsWith('../') && rel !== '..' && !isAbsolute(rel)) {
+        return { display: `workspace:${rel}`, withinWorkspace: true };
+    }
+    return { display: `external:${basename(target)}`, withinWorkspace: false };
+}
+
+/**
+ * @param {string | null} path
+ * @returns {Promise<boolean | null>}
+ */
+async function pathExists(path) {
+    if (!path) return null;
+    try {
+        await statPath(path, { advisoryLimits: { source: 'session.fs.state' } });
+        return true;
+    } catch (error) {
+        if (isNotFoundError(error)) return false;
+        throw error;
+    }
 }
 
 /**
@@ -393,6 +426,63 @@ export function buildConfiguredClientSessionFsConfig() {
         initialCwd: config.initialCwd,
         sessionStatePath: config.sessionStatePath,
         conventions: config.conventions,
+    };
+}
+
+/**
+ * Descreve a configuração e os caminhos de SessionFs sem expor paths absolutos fora do workspace.
+ *
+ * @param {string | null | undefined} [sessionId]
+ * @returns {{
+ *     enabled: boolean;
+ *     initialCwd: string;
+ *     sessionStatePath: string;
+ *     conventions: 'windows' | 'posix';
+ *     storageRoot: { display: string; withinWorkspace: boolean };
+ *     session: { key: string; display: string; withinWorkspace: boolean } | null;
+ * }}
+ */
+export function describeConfiguredSessionFs(sessionId) {
+    const config = readCopilotSessionFsBootConfig();
+    const storageRootDir = resolve(config.storageRootDir);
+    const storageRoot = buildSafeSessionFsPathDisplay(storageRootDir, config.initialCwd);
+    const cleanSessionId = typeof sessionId === 'string' && sessionId.trim() ? sessionId.trim() : null;
+    const sessionKey = cleanSessionId && config.enabled ? toSessionStorageKey(cleanSessionId) : null;
+    const sessionDir = sessionKey ? resolve(storageRootDir, sessionKey) : null;
+    const session = sessionKey && sessionDir ? buildSafeSessionFsPathDisplay(sessionDir, config.initialCwd) : null;
+    return {
+        enabled: config.enabled,
+        initialCwd: config.initialCwd,
+        sessionStatePath: config.sessionStatePath,
+        conventions: config.conventions,
+        storageRoot,
+        session: sessionKey && session ? { key: sessionKey, ...session } : null,
+    };
+}
+
+/**
+ * Lê estado operacional mínimo de SessionFs para cockpit/diagnóstico.
+ *
+ * @param {string | null | undefined} [sessionId]
+ * @returns {Promise<ReturnType<typeof describeConfiguredSessionFs> & {
+ *     storageRoot: ReturnType<typeof describeConfiguredSessionFs>['storageRoot'] & { exists: boolean | null };
+ *     session: (NonNullable<ReturnType<typeof describeConfiguredSessionFs>['session']> & { exists: boolean | null }) | null;
+ * }>}
+ */
+export async function readConfiguredSessionFsState(sessionId) {
+    const descriptor = describeConfiguredSessionFs(sessionId);
+    const config = readCopilotSessionFsBootConfig();
+    const storageRootDir = resolve(config.storageRootDir);
+    const sessionDir =
+        descriptor.enabled && descriptor.session ? resolve(storageRootDir, descriptor.session.key) : null;
+    const [storageRootExists, sessionExists] = await Promise.all([
+        descriptor.enabled ? pathExists(storageRootDir) : Promise.resolve(null),
+        descriptor.enabled ? pathExists(sessionDir) : Promise.resolve(null),
+    ]);
+    return {
+        ...descriptor,
+        storageRoot: { ...descriptor.storageRoot, exists: storageRootExists },
+        session: descriptor.session ? { ...descriptor.session, exists: sessionExists } : null,
     };
 }
 

--- a/src/copilot/terminal/commands/session.js
+++ b/src/copilot/terminal/commands/session.js
@@ -896,6 +896,96 @@ function renderSdkSessionSummaryPreview(summary) {
 }
 
 /**
+ * @param {string} action
+ * @param {string} rawAction
+ * @param {string[]} rest
+ * @returns {{ limit: number; offset: number; filter: import('#copilot/sdk/types').SessionListFilter | undefined; filterLabel: string }}
+ */
+function parseSdkSessionInventoryArgs(action, rawAction, rest) {
+    const tokens = action === 'status' || action === 'list' || action === 'ls' ? rest : [rawAction, ...rest];
+    let limit = 12;
+    let offset = 0;
+    /** @type {import('#copilot/sdk/types').SessionListFilter} */
+    const filter = {};
+    for (const token of tokens) {
+        if (/^\d+$/u.test(token)) {
+            limit = Math.min(100, Math.max(1, Number.parseInt(token, 10)));
+            continue;
+        }
+        const [key, ...valueParts] = token.split('=');
+        const value = valueParts.join('=').trim();
+        if (!key || !value) continue;
+        if (key === 'offset' && /^\d+$/u.test(value)) {
+            offset = Math.max(0, Number.parseInt(value, 10));
+        } else if (key === 'cwd') {
+            filter.cwd = value;
+        } else if (key === 'gitRoot') {
+            filter.gitRoot = value;
+        } else if (key === 'repository' || key === 'repo') {
+            filter.repository = value;
+        } else if (key === 'branch') {
+            filter.branch = value;
+        }
+    }
+    const filterEntries = Object.entries(filter);
+    return {
+        limit,
+        offset,
+        filter: filterEntries.length > 0 ? filter : undefined,
+        filterLabel: filterEntries.length > 0 ? filterEntries.map(([key, value]) => `${key}=${value}`).join(' · ') : 'none',
+    };
+}
+
+/**
+ * @param {unknown} state
+ * @returns {string}
+ */
+function renderSdkSessionFsState(state) {
+    if (!state || typeof state !== 'object') return 'n/d';
+    const record = /** @type {Record<string, unknown>} */ (state);
+    if (record['enabled'] !== true) return 'disabled';
+    const root = record['storageRoot'] && typeof record['storageRoot'] === 'object'
+        ? /** @type {Record<string, unknown>} */ (record['storageRoot'])
+        : null;
+    const session = record['session'] && typeof record['session'] === 'object'
+        ? /** @type {Record<string, unknown>} */ (record['session'])
+        : null;
+    const rootDisplay = typeof root?.['display'] === 'string' ? root['display'] : '(root n/d)';
+    const rootExists = root?.['exists'] === true ? 'exists' : root?.['exists'] === false ? 'missing' : 'unknown';
+    const sessionDisplay = typeof session?.['display'] === 'string' ? session['display'] : null;
+    const sessionExists =
+        session?.['exists'] === true ? 'exists' : session?.['exists'] === false ? 'missing' : session ? 'unknown' : null;
+    const statePath = typeof record['sessionStatePath'] === 'string' ? record['sessionStatePath'] : '(state n/d)';
+    return `on · root=${rootDisplay}(${rootExists}) · state=${statePath}${
+        sessionDisplay ? ` · session=${sessionDisplay}(${sessionExists ?? 'unknown'})` : ''
+    }`;
+}
+
+/**
+ * @param {Record<string, unknown> | null | undefined} metadata
+ * @returns {string | null}
+ */
+function renderSdkSessionLocalMetadata(metadata) {
+    if (!metadata) return null;
+    const model = typeof metadata['model'] === 'string' && metadata['model'] ? metadata['model'] : null;
+    const provider = metadata['provider'] && typeof metadata['provider'] === 'object'
+        ? /** @type {Record<string, unknown>} */ (metadata['provider'])
+        : null;
+    const boundary = metadata['boundary'] && typeof metadata['boundary'] === 'object'
+        ? /** @type {Record<string, unknown>} */ (metadata['boundary'])
+        : null;
+    const providerKind = typeof provider?.['kind'] === 'string' ? provider['kind'] : null;
+    const providerModel = typeof provider?.['model'] === 'string' ? provider['model'] : null;
+    const reason = typeof boundary?.['reason'] === 'string' ? boundary['reason'] : null;
+    const parts = [
+        model ? `model=${model}` : null,
+        providerKind ? `provider=${providerKind}${providerModel && providerModel !== model ? `:${providerModel}` : ''}` : null,
+        reason ? `boundary=${reason}` : null,
+    ].filter(Boolean);
+    return parts.length > 0 ? parts.join(' · ') : null;
+}
+
+/**
  * @param {unknown} value
  * @param {number} [max]
  * @returns {string}
@@ -1269,11 +1359,14 @@ export async function cmdSessionSdk({ println }, arg = '') {
         return;
     }
 
-    const limit = Number.parseInt(action === 'status' ? (rest[0] ?? '') : rawAction, 10);
+    const inventoryArgs = parseSdkSessionInventoryArgs(action, rawAction, rest);
     const bootSelection = await readTerminalSdkSessionBootSelection();
     let inventory;
     try {
-        inventory = await listTerminalSdkSessionInventory(runtimeId);
+        inventory = await listTerminalSdkSessionInventory(runtimeId, inventoryArgs.filter, {
+            enrichOffset: inventoryArgs.offset,
+            enrichLimit: inventoryArgs.limit,
+        });
     } catch (error) {
         println(`  \x1b[31mNão foi possível listar sessões SDK: ${toError(error).message}\x1b[0m`);
         println('  \x1b[90mAinda assim: /resume atua no hub; /session save|list|restore atua em snapshots locais.\x1b[0m');
@@ -1291,6 +1384,7 @@ export async function cmdSessionSdk({ println }, arg = '') {
     println(`    last SDK:       \x1b[33m${inventory.lastSessionId ?? '-'}\x1b[0m`);
     println(`    foreground SDK: \x1b[33m${inventory.foregroundSessionId ?? '-'}\x1b[0m`);
     println(`    próximo boot:   \x1b[33m${nextLabel}\x1b[0m`);
+    println(`    session fs:     \x1b[90m${renderSdkSessionFsState(inventory.sessionFs)}\x1b[0m`);
     const byokBinding = classifyTerminalByokSdkBinding(
         readTerminalByokProjection().summary,
         inventory.persistedByokBinding,
@@ -1313,9 +1407,12 @@ export async function cmdSessionSdk({ println }, arg = '') {
         println('    \x1b[90mNenhuma sessão SDK listada pelo client atual.\x1b[0m\n');
         return;
     }
-    println(`\n  \x1b[36mSessões SDK listadas\x1b[0m (${inventory.sessions.length})`);
-    const visibleSessions = inventory.sessions.slice(0, Number.isFinite(limit) && limit > 0 ? limit : 12);
+    println(
+        `\n  \x1b[36mSessões SDK listadas\x1b[0m (${inventory.sessions.length}) \x1b[90mfiltro=${inventoryArgs.filterLabel} · offset=${inventoryArgs.offset} · limit=${inventoryArgs.limit}\x1b[0m`,
+    );
+    const visibleSessions = inventory.sessions.slice(inventoryArgs.offset, inventoryArgs.offset + inventoryArgs.limit);
     for (const [index, entry] of visibleSessions.entries()) {
+        const absoluteIndex = inventoryArgs.offset + index;
         const flags = [
             entry.sessionId === inventory.currentSessionId ? 'atual' : null,
             entry.sessionId === inventory.lastSessionId ? 'last' : null,
@@ -1329,17 +1426,29 @@ export async function cmdSessionSdk({ println }, arg = '') {
         const modified =
             entry.modifiedTime instanceof Date ? entry.modifiedTime.toISOString() : String(entry.modifiedTime ?? '-');
         const summary = renderSdkSessionSummaryPreview(entry.summary);
-        println(`    \x1b[90m#${index + 1}\x1b[0m \x1b[33m${entry.sessionId}\x1b[0m  \x1b[90m${flags || '-'}\x1b[0m`);
+        const localMetadata = renderSdkSessionLocalMetadata(
+            entry.localMetadata && typeof entry.localMetadata === 'object'
+                ? /** @type {Record<string, unknown>} */ (entry.localMetadata)
+                : null,
+        );
+        println(`    \x1b[90m#${absoluteIndex + 1}\x1b[0m \x1b[33m${entry.sessionId}\x1b[0m  \x1b[90m${flags || '-'}\x1b[0m`);
         println(`      \x1b[90mstart=${start} · modified=${modified}${summary ? ` · ${summary}` : ''}\x1b[0m`);
+        if (localMetadata) {
+            println(`      \x1b[90mmetadata local: ${localMetadata}\x1b[0m`);
+        }
+        if (entry.sessionFs) {
+            println(`      \x1b[90msession fs: ${renderSdkSessionFsState(entry.sessionFs)}\x1b[0m`);
+        }
     }
-    if (inventory.sessions.length > visibleSessions.length) {
+    if (inventory.sessions.length > inventoryArgs.offset + visibleSessions.length) {
         println(
-            `    \x1b[90m... ${inventory.sessions.length - visibleSessions.length} sessão(ões) omitida(s). Amplie com /session sdk <n>.\x1b[0m`,
+            `    \x1b[90m... ${inventory.sessions.length - inventoryArgs.offset - visibleSessions.length} sessão(ões) omitida(s). Use /session sdk ${inventoryArgs.limit} offset=${inventoryArgs.offset + visibleSessions.length}.\x1b[0m`,
         );
     }
     println(
         '\n  \x1b[90mPróximo boot: /session sdk next new | /session sdk next resume <id|#n|current|last|foreground> | /session sdk next auto\x1b[0m',
     );
+    println('  \x1b[90mFiltros: /session sdk <n> offset=<n> cwd=<path> gitRoot=<path> repo=<owner/repo> branch=<nome>.\x1b[0m');
     println('  \x1b[90mLimpeza persistida: /session sdk delete <id|#n>; sessão viva é protegida contra exclusão.\x1b[0m');
     println('  \x1b[90mprobe-residue marca canários persistidos por diagnósticos antigos; probes novos usam sessão efêmera.\x1b[0m\n');
 }

--- a/src/copilot/terminal/frontend/gateways/sdk-session.js
+++ b/src/copilot/terminal/frontend/gateways/sdk-session.js
@@ -747,10 +747,11 @@ export async function getTerminalSdkUsageMetrics(runtimeId) {
 /**
  * @param {string | null | undefined} [runtimeId]
  * @param {import('#copilot/sdk/types').SessionListFilter} [filter]
+ * @param {{ enrichOffset?: number; enrichLimit?: number }} [options]
  * @returns {ReturnType<typeof listAgentSdkSessionInventory>}
  */
-export async function listTerminalSdkSessionInventory(runtimeId, filter) {
-    return listAgentSdkSessionInventory(runtimeId, filter);
+export async function listTerminalSdkSessionInventory(runtimeId, filter, options) {
+    return listAgentSdkSessionInventory(runtimeId, filter, options);
 }
 
 /**

--- a/tests/unit/copilot/sdk/test_sdk_session_fs.spec.js
+++ b/tests/unit/copilot/sdk/test_sdk_session_fs.spec.js
@@ -10,8 +10,10 @@ import {
     buildConfiguredClientSessionFsConfig,
     createLocalSessionFsProvider,
     createWorkspaceSessionFsHandler,
+    describeConfiguredSessionFs,
     getConfiguredSessionFsHandler,
     getConfiguredSessionIdleTimeoutSeconds,
+    readConfiguredSessionFsState,
 } from '../../../../src/copilot/sdk/session/session-fs.js';
 import { setSdkMetricEmitter } from '../../../../src/copilot/sdk/telemetry/operation-metrics.js';
 
@@ -199,6 +201,30 @@ describe('sdk/session-fs', () => {
         });
         expect(getConfiguredSessionIdleTimeoutSeconds()).toBe(900);
         expect(typeof getConfiguredSessionFsHandler()).toBe('function');
+    });
+
+    it('describeConfiguredSessionFs e readConfiguredSessionFsState expõem paths seguros e estado por sessão', async () => {
+        const storageRootDir = await createTempDir();
+        process.env.COPILOT_SDK_SESSION_FS_ENABLED = 'true';
+        process.env.COPILOT_SDK_SESSION_FS_ROOT = storageRootDir;
+
+        const descriptor = describeConfiguredSessionFs('sess-A');
+        expect(descriptor.enabled).toBe(true);
+        expect(descriptor.storageRoot.display).toBe(`external:${storageRootDir.split('/').pop()}`);
+        expect(descriptor.storageRoot.withinWorkspace).toBe(false);
+        expect(descriptor.session?.key).toBe('sess-A');
+        expect(descriptor.session?.display).toBe('external:sess-A');
+
+        const stateBefore = await readConfiguredSessionFsState('sess-A');
+        expect(stateBefore.storageRoot.exists).toBe(true);
+        expect(stateBefore.session?.exists).toBe(false);
+
+        const handler = createWorkspaceSessionFsHandler({ storageRootDir });
+        const provider = handler(/** @type {any} */ ({ sessionId: 'sess-A' }));
+        await provider.writeFile('state.txt', 'ok');
+
+        const stateAfter = await readConfiguredSessionFsState('sess-A');
+        expect(stateAfter.session?.exists).toBe(true);
     });
 
     it('não expõe config quando SessionFs está desabilitado', () => {

--- a/tests/unit/copilot/terminal/test_commands_session.spec.js
+++ b/tests/unit/copilot/terminal/test_commands_session.spec.js
@@ -721,6 +721,63 @@ describe('commands/session — async commands', () => {
         expect(ctx.output()).not.toContain('delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta delta');
     });
 
+    it('cmdSessionSdk pagina, filtra e mostra metadata local/session fs segura', async () => {
+        listTerminalSdkSessionInventory.mockResolvedValueOnce({
+            currentSessionId: 'sdk-current',
+            lastSessionId: 'sdk-last',
+            foregroundSessionId: null,
+            sessionFs: {
+                enabled: true,
+                sessionStatePath: '.copilot/session-state',
+                storageRoot: { display: 'workspace:.copilot/sdk-session-fs', exists: true },
+                session: { display: 'workspace:.copilot/sdk-session-fs/sdk-current', exists: true },
+            },
+            sessions: [
+                {
+                    sessionId: 'sdk-first',
+                    startTime: new Date('2026-05-21T00:00:00.000Z'),
+                    modifiedTime: new Date('2026-05-21T00:01:00.000Z'),
+                    summary: 'primeira',
+                    isRemote: false,
+                },
+                {
+                    sessionId: 'sdk-current',
+                    startTime: new Date('2026-05-21T00:02:00.000Z'),
+                    modifiedTime: new Date('2026-05-21T00:03:00.000Z'),
+                    summary: 'atual',
+                    isRemote: false,
+                    localMetadata: {
+                        model: 'kilo-auto/free',
+                        provider: { kind: 'byok', model: 'kilo-auto/free' },
+                        boundary: { reason: 'provider-boundary: binding BYOK model mudou' },
+                    },
+                    sessionFs: {
+                        enabled: true,
+                        sessionStatePath: '.copilot/session-state',
+                        storageRoot: { display: 'workspace:.copilot/sdk-session-fs', exists: true },
+                        session: { display: 'workspace:.copilot/sdk-session-fs/sdk-current', exists: true },
+                    },
+                },
+            ],
+        });
+        const ctx = mockCtx();
+        await cmdSessionSdk({ println: ctx.println }, '1 offset=1 branch=main repo=owner/repo');
+        expect(listTerminalSdkSessionInventory).toHaveBeenCalledWith(null, {
+            branch: 'main',
+            repository: 'owner/repo',
+        }, {
+            enrichLimit: 1,
+            enrichOffset: 1,
+        });
+        expect(ctx.output()).toContain('filtro=branch=main');
+        expect(ctx.output()).toContain('offset=1');
+        expect(ctx.output()).toContain('session fs:');
+        expect(ctx.output()).toContain('workspace:.copilot/sdk-session-fs');
+        expect(ctx.output()).toContain('metadata local: model=kilo-auto/free');
+        expect(ctx.output()).toContain('boundary=provider-boundary');
+        expect(ctx.output()).not.toContain('sdk-first');
+    });
+
     it('cmdSessionSdk agenda uma sessão nova para o próximo boot', async () => {
         const ctx = mockCtx();
         await cmdSessionSdk({ println: ctx.println }, 'next new');


### PR DESCRIPTION
## Summary

- Adds canonical SessionFs descriptors/state readers that expose safe path labels and existence state without leaking absolute external paths.
- Persists redacted local SDK session metadata by `sessionId` for provider/model/reasoning/boundary, avoiding non-existent SDK APIs such as `session.updateMetadata`.
- Enriches `/session sdk` with Session FS state, local metadata, filters, and pagination while keeping deletion protection for the live SDK session.
- Updates the canonical roadmap with the Faixa F investigation and implementation notes.

## Validation

- `npm run lint:copilot` PASS
- `npm run typecheck:strict:src.copilot -- --pretty false` PASS
- `node scripts/ci/run-vitest-copilot.mjs tests/unit/copilot/sdk/test_sdk_session_fs.spec.js tests/unit/copilot/terminal/test_commands_session.spec.js` PASS
- `node scripts/ci/run-vitest-copilot.mjs tests/unit/copilot/sdk/test_sdk_session_fs.spec.js tests/unit/copilot/terminal/test_commands_session.spec.js tests/unit/copilot/contracts/test_owner_sovereignty_block_a.spec.js` still FAILS only on the pre-existing `hooks/session-hooks.js` sovereignty finding; the transient presentation->sdk import introduced during this work was removed.
- `npm run test:copilot` was run and still FAILS on broader existing suite issues outside this Faixa F change set; details are recorded in the roadmap update.